### PR TITLE
fix: move event to now+interval if sleep was long

### DIFF
--- a/sampling/thapi_sampling.c
+++ b/sampling/thapi_sampling.c
@@ -74,6 +74,8 @@ void * thapi_sampling_loop(void *args) {
            time_cmp(&(*entry)->next, &now) < 0) {
       (*entry)->pfn();
       time_add(&(*entry)->next, &(*entry)->next, &(*entry)->interval);
+      if(time_cmp(&(*entry)->next, &now) < 0)
+	      time_add(&(*entry)->next, &now, &(*entry)->interval);
     }
     utarray_sort(thapi_sampling_events, sampling_entry_cmpw);
     entry = (struct sampling_entry **)utarray_front(thapi_sampling_events);


### PR DESCRIPTION
There's a chance that the next event should already have happened, for example when the tracing receives a SIGSTOP at the wrong time.

If this happens, we move the event to now+interval.