### PR TITLE
We should not call next_status when BT_MESSAGE_ITERATOR_CLASS_NEXT_METHOD_STATUS_END was returned

### DIFF
--- a/xprof/interval.c.erb
+++ b/xprof/interval.c.erb
@@ -6,7 +6,6 @@
 #include "uthash.h"
 #include "utarray.h"
 
-
 // Global variable used to path some handle from the
 // <%= namespace %>_dispatch_message_iterator_next to the callbacks
 struct <%= namespace %>_message_iterator *<%= namespace %>_iter_g = NULL;
@@ -235,24 +234,31 @@ bt_message_iterator_class_next_method_status <%= namespace %>_dispatch_message_i
 
 consume_upstream_messages:
 
-    next_status = bt_message_iterator_next(dispatch_iter->message_iterator,
-        &upstream_messages, &upstream_message_count);
+    next_status = BT_MESSAGE_ITERATOR_NEXT_STATUS_OK;
+
+    if (!<%= namespace %>_last_call) {
+      // We cannot call bt_message_iterator_next if previously returned BT_MESSAGE_ITERATOR_NEXT_STATUS_END
+      next_status = bt_message_iterator_next(dispatch_iter->message_iterator,
+            &upstream_messages, &upstream_message_count);
+      if (next_status == BT_MESSAGE_ITERATOR_NEXT_STATUS_END) {
+          <%= namespace %>_last_call = true;
+          bt_message *message = bt_message_stream_end_create(self_message_iterator, dispatch_iter->dispatch->stream);
+          <%= namespace %>_downstream_message_queue_push(dispatch_iter, message);
+      }
+    }
 
     /* Initialize the return status to a success */
     bt_message_iterator_class_next_method_status status =
-        BT_MESSAGE_ITERATOR_CLASS_NEXT_METHOD_STATUS_OK;
+      BT_MESSAGE_ITERATOR_CLASS_NEXT_METHOD_STATUS_OK;
 
-    if (next_status == BT_MESSAGE_ITERATOR_NEXT_STATUS_END &&  !<%= namespace %>_last_call) {
-      bt_message *message = bt_message_stream_end_create(self_message_iterator, dispatch_iter->dispatch->stream);
-      <%= namespace %>_downstream_message_queue_push(dispatch_iter, message);
-      <%= namespace %>_last_call = true;
-    }
-
-    if ( (next_status == BT_MESSAGE_ITERATOR_NEXT_STATUS_END) && <%= namespace %>_downstream_message_queue_empty(dispatch_iter) ) {
+    // No more message to send, we can exit
+    if (<%= namespace %>_last_call && <%= namespace %>_downstream_message_queue_empty(dispatch_iter) )  {
        bt_message_iterator_put_ref(dispatch_iter->message_iterator);
        status = BT_MESSAGE_ITERATOR_CLASS_NEXT_METHOD_STATUS_END;
        goto end;
     }
+    // We really on the fact that if <%= namespace %>_last_call> but we still have somne message to send,
+    // bt2 will put upstream_message_count == 0, hence we will bypass the reading step
 
     switch (next_status) {
     case BT_MESSAGE_ITERATOR_NEXT_STATUS_AGAIN:


### PR DESCRIPTION
New master segfault when channing interval (but not when running one interval, this is why I missed it. Thanks Aurelio found it)

The current interval was already broken for a long time. It's not valid to call `bt_message_iterator_next` on an ENDed iterator class.  We just got lucky that we never go enough messages in the downstream queue to call the state machine again. 

This PR fix this issue. The correct, and pretty way is to use our new state machine in metababel. 
