### PR TITLE
Add cuGetProcAddress* to list of initi functions.

### DIFF
--- a/cuda/cuda_model.rb
+++ b/cuda/cuda_model.rb
@@ -32,7 +32,7 @@ find_all_types(typedefs)
 gen_struct_map(typedefs, structs)
 gen_ffi_type_map(typedefs)
 
-INIT_FUNCTIONS = /cuInit|cuDriverGetVersion|cuGetExportTable|cuDeviceGetCount/
+INIT_FUNCTIONS = /cuInit|cuDriverGetVersion|cuGetExportTable|cuDeviceGetCount|cuGetProcAddress/
 
 HEX_INT_TYPES.push("CUdeviceptr")
 


### PR DESCRIPTION
`cuGetProcAddress` and `cuGetProcAddress_v2` can be called before cuInit, therefore they should be init functions as well.

This fixes OpenACC tracing with recent CUDA versions.