### PR TITLE
Fix xprosh.sh

### DIFF
--- a/xprof/xprof.sh.erb.in
+++ b/xprof/xprof.sh.erb.in
@@ -41,25 +41,30 @@ echoq() {
    fi
 }
 
+count_file() {
+    # https://unix.stackexchange.com/a/90152
+    a=$(2>/dev/null \ls  -afq $1 | wc -l)
+    echo $((a - 2))
+}
+
 local_barier() {
     echoq "THAPI_LOG: local_barier_entry ($1): ${PALS_RANKID:-0}"
     local folder=$SHARED_LOCAL_FILESYSTEM/lock/$1
     local path=$folder/${PALS_LOCAL_RANKID:-0}
     mkdir -p $path
-    while [ $(find $folder -mindepth 1 -maxdepth 1 -type d | wc -l || true) != ${PALS_LOCAL_SIZE:-1} ]; do
-      sleep 0.2
+    while [ $(count_file $folder) != ${PALS_LOCAL_SIZE:-1} ]; do
+        sleep 0.2
     done
-    # We cannot rmdir $path here, and I have no idea why...
+    # We cannot rmdir $path here to avoid race-condition
     echoq "THAPI_LOG: local_barier_exit ($1): ${PALS_RANKID:-0}"
 }
 
 global_barrier_epilogue() {
     echoq "THAPI_LOG: global_barrier_epilogue_entry"
     rmdir $SHARED_GLOBAL_FILESYSTEM/${PALS_RANKID:-0}
-    # Only master should wait, because after master will delete $SHARED_GLOBAL_FILESYSTEM
     if [[ ${PALS_RANKID:-0} == 0 ]]; then
-        while [ $(stat -c %h $SHARED_GLOBAL_FILESYSTEM) != 2 ]; do
-                sleep 0.2
+        while [ $(count_file $SHARED_GLOBAL_FILESYSTEM) != 0 ]; do
+           sleep 0.2
         done
     fi
     echoq "THAPI_LOG: global_barrier_epilogue_exit"


### PR DESCRIPTION
`$(stat -c %h $SHARED_GLOBAL_FILESYSTEM) != 2`  doesn't work as I Was thinking...

```
tapplencourt@gene-lxc:~$ ls /home/tapplencourt/.thapi_lock/
toto  toto2
tapplencourt@gene-lxc:~$ stat /home/tapplencourt/.thapi_lock/
  File: /home/tapplencourt/.thapi_lock/
  Size: 18        	Blocks: 0          IO Block: 4096   directory
Device: 40h/64d	Inode: 13666303    Links: 1
Access: (0775/drwxrwxr-x)  Uid: ( 1003/tapplencourt)   Gid: ( 1003/tapplencourt)
Access: 2023-07-27 17:13:07.923096752 -0500
Modify: 2023-07-27 17:11:41.057635055 -0500
Change: 2023-07-27 17:11:41.057635055 -0500
 Birth: 2023-07-27 17:01:50.455485424 -0500
 ```
 
 ```
 applenco@x1921c0s1b0n0:~> ls .thapi_lock/
0  1
applenco@x1921c0s1b0n0:~> stat .thapi_lock/
  File: .thapi_lock/
  Size: 4096      	Blocks: 8          IO Block: 4096   directory
Device: bf36f4fah/3208049914d	Inode: 144117492476825683  Links: 4
Access: (0755/drwxr-xr-x)  Uid: (32658/applenco)   Gid: (  100/   users)
Access: 2023-07-27 22:12:14.000000000 +0000
Modify: 2023-07-27 22:12:30.000000000 +0000
Change: 2023-07-27 22:12:30.000000000 +0000
 Birth: -
 ```
 
 Yes I know, bash sucks... 
 (Please somebody try the change, JLSE down) 
 
 Thanks @kevin-harms 