### PR TITLE
APIs need to be in reverse order of their versions.

### DIFF
--- a/cuda/extract_cuda_versions.rb
+++ b/cuda/extract_cuda_versions.rb
@@ -12,4 +12,6 @@ ARGV.each { |path|
   }
 }
 
+apis.each { |api, suffixes| suffixes.each { |suffix, versions| versions.sort!.reverse! } }
+
 puts YAML::dump(apis)


### PR DESCRIPTION
`cuGetProcAddress` version where in incorrect order in the header leading to only `cuGetProcAddress_v2` being traced. This enforces the correct ordering.