### PR TITLE
Add on node processing

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -131,6 +131,7 @@ def get_components(names)
   # BT "native" component classes
   components_classes = {
     'source.ctf.fs' => BT2::BTPlugin.find('ctf').get_source_component_class_by_name('fs'),
+    'source.ctf.lttng_live' => BT2::BTPlugin.find('ctf').get_source_component_class_by_name('lttng-live'),
     'filter.utils.muxer' => BT2::BTPlugin.find('utils').get_filter_component_class_by_name('muxer'),
     'sink.text.pretty' => BT2::BTPlugin.find('text').get_sink_component_class_by_name('pretty'),
     'sink.ctf.fs' => BT2::BTPlugin.find('ctf').get_sink_component_class_by_name('fs'),
@@ -216,6 +217,10 @@ def get_and_add_components(graph, names)
     case name
     when 'sink.text.rubypretty'
       graph.add_simple_sink('rubypretty', comp)
+    when 'source.ctf.lttng_live'
+      graph.add(comp, 'source_live',
+                params: { 'inputs' => $options[:inputs],
+                          'session-not-found-action' => 'end' })
     when 'source.ctf.fs'
       Find.find(*ARGV)
           .reject { |path| FileTest.directory?(path) }
@@ -357,11 +362,14 @@ thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.inter
                 'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                'sink.btx_timeline.timeline'],
                 'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
+                'trace_live' => ['source.ctf.lttng_live', 'filter.utils.muxer', 'sink.text.rubypretty'],
                 'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval', 'sink.ctf.fs'],
                 'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                 'filter.btx_aggreg.aggreg', 'sink.ctf.fs'] }
 
 graph = BT2::BTGraph.new
+
+command = 'trace_live' if command == 'trace' && $options[:live]
 comp = get_and_add_components(graph, thapi_graph[command])
 connects(graph, comp)
 

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -74,8 +74,8 @@ module BTComponentClassRefinement
     attr_accessor :plugins_path, :cli_v
 
     def add(component_class, name, params: {},
-                      logging_level: BT2::BTLogging.default_level,
-                      initialize_method_data: nil)
+            logging_level: BT2::BTLogging.default_level,
+            initialize_method_data: nil)
 
       @plugins_path << component_class.plugin.path
       @cli_v << "--component #{name}:#{component_class.type.to_s.split('_').last.downcase}.#{component_class.plugin.name}.#{component_class.name}"
@@ -160,22 +160,24 @@ def get_components(names)
       require 'babeltrace_hip_lib' if $options[:backends].include?('hip')
       # I guess need to put it in `babeltrace_energy_lib` at some point?
 
-      $energies={}
-      $event_lambdas["lttng_ust_ze_sampling:gpu_energy"] = lambda { |defi|
-        energy = defi['energy']
-        timestamp = defi['timestamp']
+      $energies = {}
+      if $options[:backends].include?('ze')
+        $event_lambdas['lttng_ust_ze_sampling:gpu_energy'] = lambda { |defi|
+          energy = defi['energy']
+          timestamp = defi['timestamp']
 
-        key = [ defi['hDevice'], defi['domain'] ]
-        previous = $energies[key]
-        $energies[key] = [energy, timestamp]
+          key = [defi['hDevice'], defi['domain']]
+          previous = $energies[key]
+          $energies[key] = [energy, timestamp]
 
-        if previous
-          p_energy, p_timestamp = previous
-          "#{key[0]}:#{key[1]}: #{(energy - p_energy).to_f/(timestamp - p_timestamp)}"
-        else
-          ""
-        end
-      } if $options[:backends].include?('ze')
+          if previous
+            p_energy, p_timestamp = previous
+            "#{key[0]}:#{key[1]}: #{(energy - p_energy).to_f / (timestamp - p_timestamp)}"
+          else
+            ''
+          end
+        }
+      end
 
       f = lambda { |iterator, _|
         iterator.next_messages.each do |m|
@@ -189,7 +191,11 @@ def get_components(names)
           if $options[:context]
             str << " - #{e.stream.trace.get_environment_entry_value_by_name('hostname')}"
             common_context_field = e.get_common_context_field
-            str << " - " << common_context_field.value.collect { |k, v| "#{k}: #{v}" }.join(", ") if common_context_field
+            if common_context_field
+              str << ' - ' << common_context_field.value.collect do |k, v|
+                "#{k}: #{v}"
+              end.join(', ')
+            end
           end
           str << " - #{e.name}: "
           str << (l ? l.call(e.payload_field.value) : e.payload_field.to_s)
@@ -204,7 +210,7 @@ def get_components(names)
 end
 
 def get_and_add_components(graph, names)
-  get_components(names).map do |nc|
+  get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
     case name
@@ -231,9 +237,11 @@ def get_and_add_components(graph, names)
     when 'sink.btx_tally.tally'
       graph.add(comp, 'tally',
                 params: $options_tally.transform_values { |_, v| v })
+    when 'filter.utils.muxer'
+      graph.add(comp, name) unless $options[:'no-muxer']
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
-      graph.add(comp, name.gsub('.','_'))
+      graph.add(comp, name.gsub('.', '_'))
     end
   end
 end
@@ -254,6 +262,10 @@ def common_options(opts)
 
   opts.on('--debug') do |_v|
     $options[:debug] = true
+  end
+
+  opts.on('--no-muxer') do |_v|
+    $options[:'no-muxer'] = true
   end
 
   opts.on('-v', '--version', 'Print the version string') do
@@ -306,10 +318,6 @@ subcommands = {
       opts.banner = 'Usage: tally [OPTIONS] trace_directory...'
       common_options(opts)
 
-      opts.on('--live', 'Enable live display of the trace') do
-        $options[:live] = true
-      end
-
       $options_tally.each do |k, (t, _)|
         opts.on("--#{k}=VALUE", t) do |v|
           $options_tally[k] = [t, v]
@@ -335,6 +343,15 @@ subcommands[command].order!
 # Fix segfault
 ARGV.uniq!
 
+if $options[:'no-muxer']
+  # We need a metababel plugin to read multiple port who come from the source.
+  # And they need to be first
+  h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 0, 'ze' => 0 }
+  raise if ($options[:backends] & h.filter_map { |k, v| k if v == 1 }).empty?
+
+  $options[:backends] = $options[:backends].sort_by { |k| h[k] }
+end
+
 thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                             'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
                 'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
@@ -342,7 +359,7 @@ thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.inter
                 'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
                 'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval', 'sink.ctf.fs'],
                 'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
-                                'filter.btx_aggreg.aggreg', 'sink.ctf.fs'],
+                                'filter.btx_aggreg.aggreg', 'sink.ctf.fs'] }
 
 graph = BT2::BTGraph.new
 comp = get_and_add_components(graph, thapi_graph[command])
@@ -354,7 +371,7 @@ if $options[:debug]
   # puts cli
   puts "babeltrace_thapi: babeltrace2 cli command will be saved in ./#{name}"
   $stdout.flush
-  File.open(name, 'w') { |f| f.write(cli) }
+  File.write(name, cli)
 end
 
 graph.run

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -131,7 +131,6 @@ def get_components(names)
   # BT "native" component classes
   components_classes = {
     'source.ctf.fs' => BT2::BTPlugin.find('ctf').get_source_component_class_by_name('fs'),
-    'source.ctf.lttng_live' => BT2::BTPlugin.find('ctf').get_source_component_class_by_name('lttng-live'),
     'filter.utils.muxer' => BT2::BTPlugin.find('utils').get_filter_component_class_by_name('muxer'),
     'sink.text.pretty' => BT2::BTPlugin.find('text').get_sink_component_class_by_name('pretty'),
     'sink.ctf.fs' => BT2::BTPlugin.find('ctf').get_sink_component_class_by_name('fs'),
@@ -211,10 +210,6 @@ def get_and_add_components(graph, names)
     case name
     when 'sink.text.rubypretty'
       graph.add_simple_sink('rubypretty', comp)
-    when 'source.ctf.lttng_live'
-      graph.add(comp, 'source_live',
-                params: { 'inputs' => $options[:inputs],
-                          'session-not-found-action' => 'end' })
     when 'source.ctf.fs'
       Find.find(*ARGV)
           .reject { |path| FileTest.directory?(path) }
@@ -290,15 +285,18 @@ subcommands = {
         $options[:live] = true
       end
     end,
-  'live2aggreg' =>
+  'to_interval' =>
     OptionParser.new do |opts|
-      opts.banner = 'Usage: live2aggreg [OPTIONS]'
+      opts.banner = 'Usage: to_interval [OPTIONS]'
       common_options(opts)
-
-      opts.on('--inputs=INPUTS') do |inputs|
-        $options[:inputs] = [inputs]
+      opts.on('--output=OUTPUT') do |output|
+        $options[:output] = output
       end
-
+    end,
+  'to_aggreg' =>
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: to_aggreg [OPTIONS]'
+      common_options(opts)
       opts.on('--output=OUTPUT') do |output|
         $options[:output] = output
       end
@@ -311,17 +309,6 @@ subcommands = {
       opts.on('--live', 'Enable live display of the trace') do
         $options[:live] = true
       end
-
-      $options_tally.each do |k, (t, _)|
-        opts.on("--#{k}=VALUE", t) do |v|
-          $options_tally[k] = [t, v]
-        end
-      end
-    end,
-  'aggreg2tally' =>
-    OptionParser.new do |opts|
-      opts.banner = 'Usage: aggreg2tally [OPTIONS] trace_directory...'
-      common_options(opts)
 
       $options_tally.each do |k, (t, _)|
         opts.on("--#{k}=VALUE", t) do |v|
@@ -353,9 +340,9 @@ thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.inter
                 'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                'sink.btx_timeline.timeline'],
                 'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
-                'live2aggreg' => ['source.ctf.lttng_live', 'filter.utils.muxer', 'filter.intervals.interval',
-                                  'filter.btx_aggreg.aggreg', 'sink.ctf.fs'],
-                'aggreg2tally' => ['source.ctf.fs', 'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'] }
+                'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval', 'sink.ctf.fs'],
+                'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
+                                'filter.btx_aggreg.aggreg', 'sink.ctf.fs'],
 
 graph = BT2::BTGraph.new
 comp = get_and_add_components(graph, thapi_graph[command])

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -346,8 +346,8 @@ ARGV.uniq!
 if $options[:'no-muxer']
   # We need a metababel plugin to read multiple port who come from the source.
   # And they need to be first
-  h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 0, 'ze' => 0 }
-  raise if ($options[:backends] & h.filter_map { |k, v| k if v == 1 }).empty?
+  h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 1, 'ze' => 0 }
+  raise if ($options[:backends] & h.filter_map { |k, v| k if v == 0 }).empty?
 
   $options[:backends] = $options[:backends].sort_by { |k| h[k] }
 end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -557,29 +557,29 @@ def global_processing(folder)
       raise 'Cannot show the trace of an interval or aggregated trace'
     end
 
-    opts = 'trace '
-    opts << '--restrict '
-    opts << '--context '
-    opts << "--backend #{backends} "
+    opts = ['trace']
+    opts << '--restrict'
+    opts << '--context'
+    opts << "--backend #{backends}"
   elsif OPTIONS.include?(:timeline)
     raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
 
-    opts = 'timeline '
-    opts << "--backend #{backends} "
+    opts = ['timeline']
+    opts << "--backend #{backends}"
   else
-    opts = 'tally '
-    opts << '--display_kernel_verbose true ' if OPTIONS.include?(:'kernel-verbose')
-    opts << '--display_metadata true ' if OPTIONS.include?(:metadata)
-    opts << "--display_name_max_size #{OPTIONS[:'max-name-size']} "
-    opts << '--display_mode json ' if OPTIONS.include?(:json)
-    opts << "--backend #{backends} "
-    opts << "--backend_level #{backend_level} " unless backend_level.empty?
-    opts << '--display extended ' if OPTIONS.include?(:extended)
+    opts = ['tally']
+    opts << '--display_kernel_verbose true' if OPTIONS.include?(:'kernel-verbose')
+    opts << '--display_metadata true' if OPTIONS.include?(:metadata)
+    opts << "--display_name_max_size #{OPTIONS[:'max-name-size']}"
+    opts << '--display_mode json'  if OPTIONS.include?(:json)
+    opts << "--backend #{backends}"
+    opts << "--backend_level #{backend_level}" unless backend_level.empty?
+    opts << '--display extended' if OPTIONS.include?(:extended)
   end
 
   opts << '--no-muxer ' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
 
-  cmd = "#{BINDIR}/babeltrace_thapi #{opts} -- #{folder}"
+  cmd = "#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{folder}"
   LOGGER.debug(cmd)
   IO.popen(cmd) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -570,20 +570,20 @@ def global_processing(folder)
     args += ['tally']
     args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')
     args << '--display_metadata' << 'true' if OPTIONS.include?(:metadata)
-    args << "--display_name_max_size" << OPTIONS[:'max-name-size'].to_s
+    args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
     args << '--display_mode' << 'json' if OPTIONS.include?(:json)
-    args << "--backend" << backends
-    args << "--backend_level" << backend_level unless backend_level.empty?
+    args << '--backend' << backends
+    args << '--backend_level' << backend_level unless backend_level.empty?
     args << '--display' << 'extended' if OPTIONS.include?(:extended)
   end
 
   args << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
 
-  args += ["--", folder]
+  args += ['--', folder]
 
   LOGGER.debug(cmdname)
   LOGGER.debug(args)
-  IO.popen([cmdname,*args]) do |stdout, _stdin, _pid|
+  IO.popen([cmdname, *args]) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }
   end
 end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -122,6 +122,22 @@ def prefix_processed_trace
   end
 end
 
+
+# THAPI/xprof use multiple folter
+# - lttng_trace_dir_tmp
+#     where the 'raw' lttng trace if saved.
+#     For performance we store in a `tmp` folder.
+#     When "on the fly" analys will be possible, this should not potential OOM
+# - thapi_trace_dir_tmp
+#     Where the "pre-processed / analysed / condensed" trace a saved.
+#     Each nodes need to aggree on a root folder to write into.
+#  - thapi_trace_dir_root
+#     Final directory exposed to the user. The `master rank`  rename the `thapi_trace_dir_tmp`
+#     with a more "friendly" name.
+#
+#  - lttng_home_dir
+#     Home of the lttng daemon
+
 def lttng_trace_dir_tmp
   File.join('/', 'tmp', "thapi--#{mpi_job_id}", Socket.gethostname)
 end
@@ -135,8 +151,6 @@ def lttng_home_dir
   File.join('/', 'tmp', "lttng_home--#{mpi_job_id}")
 end
 
-# Put the date on the directory name, can be removed from another naming scheme
-# Or we can can the data beffore
 def thapi_trace_dir_root
   raise unless mpi_master?
 
@@ -432,18 +446,18 @@ end
 def setup_lttng(backends)
   raise unless mpi_local_master?
 
-  # Daemon will crash if LTTNG_HOME doesn't exist
+  # Spawning the sessiond Daemon will crash
+  #   if LTTNG_HOME doesn't exist
   FileUtils.mkdir_p(lttng_home_dir)
 
-  # The daemon will be cleaned in the teardown
   exec('lttng-sessiond --daemonize')
-
   exec("lttng create #{lttng_session_uuid} -o #{lttng_trace_dir_tmp}")
 
   channel_name = 'blocking-channel'
   exec("lttng enable-channel --userspace --session=#{lttng_session_uuid} --blocking-timeout=inf #{channel_name}")
   exec("lttng add-context    --userspace --session=#{lttng_session_uuid} --channel=#{channel_name} -t vpid -t vtid")
 
+  # Enable backend events
   (backends + ['metadata']).each do |name|
     send("enable_events_#{name}", channel_name,
          tracing_mode: OPTIONS[:tracing_mode],
@@ -454,13 +468,15 @@ end
 
 def teardown_lttng
   exec("lttng destroy #{lttng_session_uuid}")
-  # Need to kill the sessiond. It's safe because each job has their own
-  #   In theory, opening this file is racy.
-  #   It's possible that the sessiond spawned before writing in the file
-  # In practice, there is so much work between the two. Should be ok
+  # Need to kill the sessiond Daemon. It's safe because each job has their own
+  #
+  # In theory, opening the lttng-sessiond.pid file is racy.
+  # It's possible that the sessiond spawned, and didn't yet wrote the file
+  # In practice, there is lot of work between the spawn and the write, so should be ok
   pid = File.read(File.join(lttng_home_dir, '.lttng', 'lttng-sessiond.pid')).to_i
   LOGGER.info('Killing sessiond')
   Process.kill('SIGKILL', pid)
+  FileUtils.rm_f(lttng_home_dir)
 end
 
 #    _                                   _
@@ -598,8 +614,8 @@ parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
     end
   end.to_set
 end
-parser.on('--[no-]profile', 'Triger for device activities profiling')
-parser.on('--[no-]analysis', 'Triger for analysis')
+parser.on('--[no-]profile', 'Trigger for device activities profiling')
+parser.on('--[no-]analysis', 'Trigger for analysis')
 
 # General Options
 parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -431,6 +431,7 @@ end
 
 def setup_lttng(backends)
   raise unless mpi_local_master?
+
   # Daemon will crash if LTTNG_HOME doesn't exist
   FileUtils.mkdir_p(lttng_home_dir)
 
@@ -482,7 +483,7 @@ def on_node_processing(_backends, global_barrier_h)
            'to_aggreg '
          end
 
-  if opts
+  if opts && OPTIONS[:analysis]
     opts << "--output #{thapi_trace_dir_tmp}"
     exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_trace_dir_tmp}")
     FileUtils.rm_f(lttng_trace_dir_tmp)
@@ -533,7 +534,6 @@ def global_processing(folder)
   raise unless mpi_master?
 
   LOGGER.info { "postprocess #{folder}" }
-  puts("Trace Location #{folder}")
   backends = OPTIONS[:'backend-name'].join(',')
   backend_level = OPTIONS[:backend].filter { |nl| nl.include?(':') }.join(',')
 
@@ -579,6 +579,7 @@ end
 parser = OptionParser.new
 
 options = { tracing_mode: 'default', profile: true, backend: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'],
+            analysis: true,
             'traced-ranks': Set[-1],
             'max-name-size': 80,
             debug: Logger::FATAL }
@@ -597,7 +598,8 @@ parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
     end
   end.to_set
 end
-parser.on('--[no-]profile', 'Device activities will not be profiled')
+parser.on('--[no-]profile', 'Triger for device activities profiling')
+parser.on('--[no-]analysis', 'Triger for analysis')
 
 # General Options
 parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
@@ -672,4 +674,5 @@ end
 # Right now, `replay` means no tracing.
 # But we don't have a way of disabling post-processing
 folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
-global_processing(folder) if mpi_master?
+puts("THAPI: Trace Location #{folder}")
+global_processing(folder) if OPTIONS[:analysis] && mpi_master?

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -571,13 +571,13 @@ def global_processing(folder)
     opts << '--display_kernel_verbose true' if OPTIONS.include?(:'kernel-verbose')
     opts << '--display_metadata true' if OPTIONS.include?(:metadata)
     opts << "--display_name_max_size #{OPTIONS[:'max-name-size']}"
-    opts << '--display_mode json'  if OPTIONS.include?(:json)
+    opts << '--display_mode json' if OPTIONS.include?(:json)
     opts << "--backend #{backends}"
     opts << "--backend_level #{backend_level}" unless backend_level.empty?
     opts << '--display extended' if OPTIONS.include?(:extended)
   end
 
-  opts << '--no-muxer ' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
+  opts << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
 
   cmd = "#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{folder}"
   LOGGER.debug(cmd)

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -113,7 +113,7 @@ end
 
 # Type is aggreg bs
 def prefix_processed_trace
-  if OPTIONS.include?(:trace)
+  if OPTIONS.include?(:trace) || !OPTIONS[:analysis]
     ''
   elsif OPTIONS.include?(:timeline)
     '_interval'

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -106,6 +106,63 @@ def mpi_master?
   mpi_rank_id == 0
 end
 
+#    _                    _
+#   |_ _  |  _|  _  ._   |_) _. _|_ |_
+#   | (_) | (_| (/_ |    |  (_|  |_ | |
+#
+
+# Type is aggreg bs
+def prefix_processed_trace
+  if OPTIONS.include?(:trace)
+    ''
+  elsif OPTIONS.include?(:timeline)
+    '_interval'
+  else
+    '_aggreg'
+  end
+end
+
+def lttng_trace_dir_tmp
+  File.join('/', 'tmp', "thapi--#{mpi_job_id}", Socket.gethostname)
+end
+
+def thapi_trace_dir_tmp
+  File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{mpi_job_id}",
+            Socket.gethostname)
+end
+
+def lttng_home_dir
+  File.join('/', 'tmp', "lttng_home--#{mpi_job_id}")
+end
+
+# Put the date on the directory name, can be removed from another naming scheme
+# Or we can can the data beffore
+def thapi_trace_dir_root
+  raise unless mpi_master?
+
+  @thapi_trace_dir_root ||= begin
+    # Multiple thapi can run concurrently.
+    #   To avoid any race-conditions, we try to MKDIR until we succeed
+
+    # This is solving a consensus for the name,
+    # make it simpler and only allow "rank" per job to do it
+
+    date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
+    (0..).each do |i|
+      prefix = i == 0 ? '' : "_#{i}"
+      thapi_uuid = date + prefix
+      path = File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{thapi_uuid}")
+      begin
+        Dir.mkdir(path)
+      rescue SystemCallError
+        next
+      else
+        break path
+      end
+    end
+  end
+end
+
 #    _
 #   |_)  _. ._ ._ o  _  ._
 #   |_) (_| |  |  | (/_ |
@@ -204,6 +261,10 @@ PREFIX = '@prefix@'
 DATAROOTDIR = File.join(PREFIX, 'share')
 DATADIR = DATAROOTDIR
 
+def lttng_session_uuid
+  Digest::MD5.hexdigest(lttng_trace_dir_tmp)
+end
+
 def env_tracers
   # Return the list of backends (used by local master to enable lttng events)
   # and the ENV used by any traced-ranks to preload THAPI tracers
@@ -283,32 +344,7 @@ def launch_usr_bin(env, cmd)
   end
 end
 
-def rename_root_to_human_readable_folder(lttng_output_root)
-  # Multiple thapi can run concurrently.
-  #   To avoid any race-conditions, we try to MKDIR until we succeed
-
-  # This is solving a consensus for the name,
-  # make it simpler and only allow "rank" per job to do it
-  raise unless mpi_master?
-
-  date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
-  path = (0..).each do |i|
-    prefix = i == 0 ? '' : "_#{i}"
-    path = lttng_output_root.sub("--#{mpi_job_id}", "--#{date}#{prefix}")
-    begin
-      Dir.mkdir(path)
-    rescue SystemCallError
-      next
-    else
-      break path
-    end
-  end
-  LOGGER.debug { "Rename #{lttng_output_root} -> #{path}" }
-  File.rename(lttng_output_root, path)
-  path
-end
-
-def enable_events_ze(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_ze(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   case tracing_mode
   when 'minimal'
@@ -341,7 +377,7 @@ def enable_events_ze(lttng_session_uuid, channel_name, tracing_mode: 'default', 
   end
 end
 
-def enable_events_cl(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_cl(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   case tracing_mode
   when 'full'
@@ -371,96 +407,113 @@ def enable_events_cl(lttng_session_uuid, channel_name, tracing_mode: 'default', 
   end
 end
 
-def enable_events_cuda(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_cuda(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_cuda:*")
   exec("#{lttng_enable} lttng_ust_cuda_properties")
   exec("#{lttng_enable} lttng_ust_cuda_profiling:*") if profiling
 end
 
-def enable_events_hip(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_hip(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_hip:*")
 end
 
-def enable_events_omp(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_omp(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_ompt:*target*")
 end
 
-def enable_events_metadata(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_metadata(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_thapi:*")
 end
 
-# TODO: Put in option
-# Or env_fetch_first('HOME'),
-THAPI_TMP_FOLDER_ROOT = '/tmp'
-
-def get_lttng_paths
-  #  We launch one daemon per Node
-  #  Hence, the output needs to be prefixed by hostname
-  #  so that each MPI local master can write to it
-  lttng_output = File.join(THAPI_TMP_FOLDER_ROOT, 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
-
-  # Each session will have an UUID.
-  # This will be used to set LLTNG_HOME to a uuid for this run
-  lttng_session_uuid = Digest::MD5.hexdigest(lttng_output)
-
-  # Because $HOME is shared, the sessiond daemon will not be able to get a lock.
-  #   `Error: Could not get lock file $USER/.lttng/lttng-sessiond.lck, another instance is running.`
-  #   We will use the blanket solution of setting LLTNG_HOME waiting for the more granular solution
-  lttng_home = File.join('/', 'tmp', lttng_session_uuid)
-
-  [lttng_output, lttng_session_uuid, lttng_home]
-end
-
-def setup_lttng(lttng_output, lttng_session_uuid, lttng_home, backends)
+def setup_lttng(backends)
   # Daemon will crash if LTTNG_HOME doesn't exist
-  FileUtils.mkdir_p(lttng_home)
+  FileUtils.mkdir_p(lttng_home_dir)
 
   # The daemon will be cleaned in the teardown
   exec('lttng-sessiond --daemonize')
 
-  exec("lttng create #{lttng_session_uuid} -o #{lttng_output}")
+  exec("lttng create #{lttng_session_uuid} -o #{lttng_trace_dir_tmp}")
 
   channel_name = 'blocking-channel'
   exec("lttng enable-channel --userspace --session=#{lttng_session_uuid} --blocking-timeout=inf #{channel_name}")
   exec("lttng add-context    --userspace --session=#{lttng_session_uuid} --channel=#{channel_name} -t vpid -t vtid")
 
   (backends + ['metadata']).each do |name|
-    send("enable_events_#{name}", lttng_session_uuid, channel_name,
+    send("enable_events_#{name}", channel_name,
          tracing_mode: OPTIONS[:tracing_mode],
          profiling: OPTIONS[:profile])
   end
   exec("lttng start #{lttng_session_uuid}")
 end
 
-def teardown_lttng(lttng_session_uuid, lttng_home)
+def teardown_lttng
   exec("lttng destroy #{lttng_session_uuid}")
   # Need to kill the sessiond. It's safe because each job has their own
   #   In theory, opening this file is racy.
   #   It's possible that the sessiond spawned before writing in the file
   # In practice, there is so much work between the two. Should be ok
-  pid = File.read(File.join(lttng_home, '.lttng', 'lttng-sessiond.pid')).to_i
+  pid = File.read(File.join(lttng_home_dir, '.lttng', 'lttng-sessiond.pid')).to_i
   LOGGER.info('Killing sessiond')
   Process.kill('SIGKILL', pid)
 end
 
-# Start and Stop lttng
-def trace(usr_argv)
+#    _                                   _
+#   |_)  _. |_   _  | _|_ ._ _.  _  _     )
+#   |_) (_| |_) (/_ |  |_ | (_| (_ (/_   /_
+#
+
+# TODO: Use babeltrace_thapi as a LIB not a binary
+
+def on_node_processing(_backends, global_barrier_h)
+  raise unless mpi_local_master?
+
+  opts = if OPTIONS.include?(:trace)
+           # Do move to $home
+           nil
+         elsif OPTIONS.include?(:timeline)
+           # Write Interval
+           'to_interval '
+         else
+           'to_aggreg '
+         end
+
+  if opts
+    opts << "--output #{thapi_trace_dir_tmp}"
+    exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_trace_dir_tmp}")
+    FileUtils.rm_f(lttng_trace_dir_tmp)
+  else
+    FileUtils.mkdir_p(File.dirname(thapi_trace_dir_tmp))
+    FileUtils.mv(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
+  end
+
+  # Global Barrier
+  global_barrier(global_barrier_h)
+
+  # Replace mpi_job_id with a better name
+  return unless mpi_master?
+
+  thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
+  FileUtils.mv(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+  thapi_trace_dir_root
+end
+
+# Start, Stop lttng, amd do the on-node analsysis
+def trace_and_on_node_processing(usr_argv)
   # All masters setup a future global barrier
   global_barrier_h = init_global_barrier if mpi_local_master?
 
   # Load Tracers and APILoaders Lib
   backends, h = env_tracers
 
-  # All Need to set the LLTTNG_HOME
+  # All rank need to set the LLTTNG_HOME env
   # so they can have access to the daemon
-  lttng_output, lttng_session_uuid, lttng_home = get_lttng_paths
-  ENV['LTTNG_HOME'] = lttng_home
+  ENV['LTTNG_HOME'] = lttng_home_dir
   # Only local master spawn LTTNG daemon and start session
-  setup_lttng(lttng_output, lttng_session_uuid, lttng_home, backends) if mpi_local_master?
+  setup_lttng(backends) if mpi_local_master?
   local_barier('waiting_for_lttng_setup')
   # Launch User Command
   launch_usr_bin(h, usr_argv)
@@ -470,68 +523,12 @@ def trace(usr_argv)
   local_barier('waiting_for_application_ending')
   return unless mpi_local_master?
 
-  teardown_lttng(lttng_session_uuid, lttng_home)
+  teardown_lttng
   # Preprocess trace
-  preprocess_trace(lttng_output, backends, global_barrier_h)
+  on_node_processing(backends, global_barrier_h)
 end
 
-#    _                                   _
-#   |_)  _. |_   _  | _|_ ._ _.  _  _     )
-#   |_) (_| |_) (/_ |  |_ | (_| (_ (/_   /_
-#
-
-def last_trace_saved
-  Dir[File.join(env_fetch_first('HOME'), 'lttng-traces', 'thapi*')].max_by { |f| File.mtime(f) }
-end
-
-# TODO: Use babeltrace_thapi as a LIB not a binary
-
-# The postprocess will as much as "per-node" as possible
-# TODO: In the case of replay we need to print to some error if the saved-trace is not valid
-# For now we will rely and the folder-name.
-# This is not robust, we should rely on some `metadata` sometime
-
-# postprocess_ctf_transformation
-# Handle any processing need to be done after lttng-trace where generated
-
-def preprocess_trace(lttng_output, backends, global_barrier_h)
-  raise unless mpi_local_master?
-
-  if OPTIONS.include?(:trace)
-    # Do move to $home
-    opts = nil
-    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
-  elsif OPTIONS.include?(:timeline)
-    # Write Interval
-    opts = 'to_interval '
-    opts << "--backend #{backends.join(',')} "
-    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi_interval--#{mpi_job_id}", Socket.gethostname)
-  else
-    opts = 'to_aggreg '
-    opts << "--backend #{backends.join(',')} "
-    # Write Aggreg
-    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi_aggreg--#{mpi_job_id}", Socket.gethostname)
-  end
-
-  if opts
-    opts << "--output #{ctf_output}"
-    exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_output}")
-  else
-    FileUtils.mkdir_p(File.dirname(ctf_output))
-    FileUtils.mv(lttng_output, ctf_output)
-  end
-
-  # Global Barrier
-  global_barrier(global_barrier_h)
-
-  # Replace mpi_job_id with a better name
-  rename_root_to_human_readable_folder(File.dirname(ctf_output)) if mpi_master?
-end
-
-# Handle stuff who need to be done by the master rank
-# postprocess_master
-
-def postprocess(folder)
+def global_processing(folder)
   raise unless mpi_master?
 
   LOGGER.info { "postprocess #{folder}" }
@@ -540,11 +537,17 @@ def postprocess(folder)
   backend_level = OPTIONS[:backend].filter { |nl| nl.include?(':') }.join(',')
 
   if OPTIONS.include?(:trace)
+    if folder.include?('_interval') || folder.include?('_aggreg')
+      raise 'Cannot show the trace of an interval or aggregated trace'
+    end
+
     opts = 'trace '
     opts << '--restrict '
     opts << '--context '
     opts << "--backend #{backends} "
   elsif OPTIONS.include?(:timeline)
+    raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
+
     opts = 'timeline '
     opts << "--backend #{backends} "
   else
@@ -652,20 +655,20 @@ OPTIONS = options.freeze
 # Setup Logger
 LOGGER = Logger.new($stdout)
 LOGGER.level = OPTIONS[:debug]
-
 LOGGER.debug(OPTIONS)
-
-# Action
 
 # We don't rely on the Parser-OPT default help, as it doesn't print the footer
 print_help_and_exit(parser, exit_code: 0) if OPTIONS.include?(:help)
-
 if OPTIONS.include?(:version)
   puts(File.read(File.join(DATADIR, 'version')))
   exit(0)
 end
 
+def last_trace_saved
+  Dir[File.join(env_fetch_first('HOME'), 'thapi-traces', 'thapi*')].max_by { |f| File.mtime(f) }
+end
+
 # Right now, `replay` means no tracing.
 # But we don't have a way of disabling post-processing
-folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace(ARGV)
-postprocess(folder) if mpi_master?
+folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
+global_processing(folder) if mpi_master?

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -689,5 +689,7 @@ end
 # Right now, `replay` means no tracing.
 # But we don't have a way of disabling post-processing
 folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
-puts("THAPI: Trace Location #{folder}")
-global_processing(folder) if OPTIONS[:analysis] && mpi_master?
+if mpi_master?
+  puts("THAPI: Trace Location #{folder}")
+  global_processing(folder) if OPTIONS[:analysis]
+end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -111,7 +111,7 @@ end
 #   | (_) | (_| (/_ |    |  (_|  |_ | |
 #
 
-# Type is aggreg bs
+# Prefex of the thapi_trace_dir
 def prefix_processed_trace
   if OPTIONS.include?(:trace) || !OPTIONS[:analysis]
     ''
@@ -122,10 +122,9 @@ def prefix_processed_trace
   end
 end
 
-
-# THAPI/xprof use multiple folter
+# THAPI/xprof use multiple folder
 # - lttng_trace_dir_tmp
-#     where the 'raw' lttng trace if saved.
+#     where the 'raw' lttng trace is saved.
 #     For performance we store in a `tmp` folder.
 #     When "on the fly" analys will be possible, this should not potential OOM
 # - thapi_trace_dir_tmp
@@ -193,8 +192,8 @@ FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
 SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
 SHARED_GLOBAL_FILESYSTEM = File.join(env_fetch_first('HOME'), FOLDER_JOBID)
 
-# Use a log distribution seem to be a good tradeoff
-# between being nice to the FileSystem (not to many call)
+# Use a log distribution seems to be a good tradeoff
+# between being nice to the FileSystem (not too many calls)
 # but not waiting to much
 def busy_wait(&block)
   (2..).take_while { |i| block.call && sleep(Math.log(i)) }
@@ -217,7 +216,7 @@ def local_barier(name)
 end
 
 # We don't know the total number of ranks
-#   -`PALS_NRANKS` look interesting but is not exported by default
+#   -`PALS_NRANKS` looks interesting but is not exported by default
 #   - We may want to call `MPI_INIT()` our self, but that mean liking against MPI
 #     making it a pain to install / configure THAPI
 # We don't know either how many local masters we have
@@ -225,10 +224,10 @@ end
 #   - We cannot use `PBS_NODEFILE`, as people can request N nodes, but launch <N process
 #
 # At the beginning of the script, each master will create a folder.
-# Then, when hiting the barrier, each local master will remove his file
+# Then, when hitting the barrier, each local master will remove his file
 #  and wait until no more folders exist.
 #
-# This is racy! If one thread exit the barrier before any other enter it,
+# This is racy! If one thread exits the barrier before any other enters it,
 #    this thread will pass the barrier.
 # We rely/We hope, that user will call an MPI_Barrier() && that we do enough work...
 def init_global_barrier
@@ -248,7 +247,7 @@ def global_barrier(f)
   #    then master will clean the folder to be nice to the user
   #
   # Note that `mpi_master` can see the folder empty, and hence remove it
-  #   at the same time as others threads sleep. They will wake up
+  #   at the same time as other threads sleep. They will wake up
   #   and see a deleted folder.
   # Fortunately `count_file` will return -2 for a non exciting folder
   #   hence we test for > 0 and not `!= 0`

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -549,39 +549,41 @@ def global_processing(folder)
   raise unless mpi_master?
 
   LOGGER.info { "postprocess #{folder}" }
+
   backends = OPTIONS[:'backend-name'].join(',')
   backend_level = OPTIONS[:backend].filter { |nl| nl.include?(':') }.join(',')
+
+  cmdname = "#{BINDIR}/babeltrace_thapi"
+
+  args = []
 
   if OPTIONS.include?(:trace)
     if folder.include?('_interval') || folder.include?('_aggreg')
       raise 'Cannot show the trace of an interval or aggregated trace'
     end
 
-    opts = ['trace']
-    opts << '--restrict'
-    opts << '--context'
-    opts << "--backend #{backends}"
+    args += ['trace', '--restrict', '--context', '--backend', backends]
   elsif OPTIONS.include?(:timeline)
     raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
-
-    opts = ['timeline']
-    opts << "--backend #{backends}"
+    args += ['timeline' '--backend', backends]
   else
-    opts = ['tally']
-    opts << '--display_kernel_verbose true' if OPTIONS.include?(:'kernel-verbose')
-    opts << '--display_metadata true' if OPTIONS.include?(:metadata)
-    opts << "--display_name_max_size #{OPTIONS[:'max-name-size']}"
-    opts << '--display_mode json' if OPTIONS.include?(:json)
-    opts << "--backend #{backends}"
-    opts << "--backend_level #{backend_level}" unless backend_level.empty?
-    opts << '--display extended' if OPTIONS.include?(:extended)
+    args += ['tally']
+    args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')
+    args << '--display_metadata' << 'true' if OPTIONS.include?(:metadata)
+    args << "--display_name_max_size" << OPTIONS[:'max-name-size'].to_s
+    args << '--display_mode' << 'json' if OPTIONS.include?(:json)
+    args << "--backend" << backends
+    args << "--backend_level" << backend_level unless backend_level.empty?
+    args << '--display' << 'extended' if OPTIONS.include?(:extended)
   end
 
-  opts << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
+  args << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
 
-  cmd = "#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{folder}"
-  LOGGER.debug(cmd)
-  IO.popen(cmd) do |stdout, _stdin, _pid|
+  args += ["--", folder]
+
+  LOGGER.debug(cmdname)
+  LOGGER.debug(args)
+  IO.popen([cmdname,*args]) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }
   end
 end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -430,6 +430,7 @@ def enable_events_metadata(channel_name, tracing_mode: 'default', profiling: tru
 end
 
 def setup_lttng(backends)
+  raise unless mpi_local_master?
   # Daemon will crash if LTTNG_HOME doesn't exist
   FileUtils.mkdir_p(lttng_home_dir)
 
@@ -509,7 +510,7 @@ def trace_and_on_node_processing(usr_argv)
   # Load Tracers and APILoaders Lib
   backends, h = env_tracers
 
-  # All rank need to set the LLTTNG_HOME env
+  # All ranks need to set the LLTTNG_HOME env
   # so they can have access to the daemon
   ENV['LTTNG_HOME'] = lttng_home_dir
   # Only local master spawn LTTNG daemon and start session

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -283,7 +283,7 @@ def launch_usr_bin(env, cmd)
   end
 end
 
-def rename_to_human_readable_folder(lttng_output_root)
+def rename_root_to_human_readable_folder(lttng_output_root)
   # Multiple thapi can run concurrently.
   #   To avoid any race-conditions, we try to MKDIR until we succeed
 
@@ -294,7 +294,7 @@ def rename_to_human_readable_folder(lttng_output_root)
   date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
   path = (0..).each do |i|
     prefix =  i == 0 ? '' : "_#{i}"
-    path = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{date}#{prefix}")
+    path = lttng_output_root.sub("--#{mpi_job_id}", "--#{date}#{prefix}")
     begin
       Dir.mkdir(path)
     rescue SystemCallError
@@ -392,10 +392,15 @@ def enable_events_metadata(lttng_session_uuid, channel_name, tracing_mode: 'defa
   exec("#{lttng_enable} lttng_ust_thapi:*")
 end
 
+# TODO: Put in option
+# Or env_fetch_first('HOME'),
+THAPI_TMP_FOLDER_ROOT = "/tmp"
+
 def get_lttng_paths
   #  We launch one daemon per Node
-  #  Hence, the output needs to be prefixed by hostname so that each MPI local master will write into it
-  lttng_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
+  #  Hence, the output needs to be prefixed by hostname 
+  #  so that each MPI local master can write to it
+  lttng_output = File.join(THAPI_TMP_FOLDER_ROOT, 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
 
   # Each session will have an UUID.
   # This will be used to set LLTNG_HOME to a uuid for this run
@@ -462,13 +467,10 @@ def trace(usr_argv)
   # We need to be sure that all the local ranks finished
   # before local master stops the lttng session
   local_barier('waiting_for_application_ending')
-  teardown_lttng(lttng_session_uuid, lttng_home) if mpi_local_master?
-
-  # Ensure that all traces have been written so we can post-process them
-  global_barrier(global_barrier_h) if mpi_local_master?
-
-  # Master will move all the folders to a better folder
-  rename_to_human_readable_folder(File.dirname(lttng_output)) if mpi_master?
+  return unless mpi_local_master?
+  teardown_lttng(lttng_session_uuid, lttng_home) 
+  # Preprocess trace
+  preprocess_trace(lttng_output) 
 end
 
 #    _                                   _
@@ -477,12 +479,59 @@ end
 #
 
 def last_trace_saved
-  Dir[File.join(env_fetch_first('HOME'), 'lttng-traces', 'thapi--*')].max_by { |f| File.mtime(f) }
+  Dir[File.join(env_fetch_first('HOME'), 'lttng-traces', 'thapi*')].max_by { |f| File.mtime(f) }
 end
 
 # TODO: Use babeltrace_thapi as a LIB not a binary
-def postprocess(folder, _options)
-  return unless mpi_master?
+
+# The postprocess will as much as "per-node" as possible
+# TODO: In the case of replay we need to print to some error if the saved-trace is not valid
+# For now we will rely and the folder-name. 
+# This is not robust, we should rely on some `metadata` sometime
+
+
+# postprocess_ctf_transformation
+# Handle any processing need to be done after lttng-trace where generated
+
+def preprocess_trace(lttng_output)
+  raise unless mpi_local_master?
+
+  if OPTIONS.include?(:trace)
+    # Do nothing
+    opts = nil
+    ctf_output = lttng_output
+  elsif OPTIONS.include?(:timeline)
+    # Write Interval
+    opts = 'to_interval'
+    opts << "--backend #{backends} "
+    ctf_output = File.join(HOME, 'lttng-traces', "thapi_interval--#{mpi_job_id}", Socket.gethostname)
+  else
+    opts = 'to_aggreg'
+    opts << "--backend #{backends} "
+    # Write Aggreg
+    ctf_output = File.join(HOME, 'lttng-traces', "thapi_aggreg--#{mpi_job_id}", Socket.gethostname)
+  end
+
+  if opts?
+    opts << "--output #{ctf_output}"
+    cmd = "#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_output}"
+    LOGGER.debug(cmd)
+    exec("lttng destroy #{lttng_session_uuid}")
+  end
+
+  # Global Barrier
+  global_barrier(global_barrier_h) 
+
+  # Replace mpi_job_id with a better name
+  rename_root_to_human_readable_folder(File.dirname(ctf_output)) if mpi_master?
+end
+
+
+# Handle stuff who need to be done by the master rank
+# postprocess_master
+
+def postprocess(folder)
+  raise unless mpi_master?
 
   LOGGER.info { "postprocess #{folder}" }
   puts("Trace Location #{folder}")
@@ -513,6 +562,7 @@ def postprocess(folder, _options)
   IO.popen(cmd) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }
   end
+
 end
 
 #
@@ -616,4 +666,4 @@ end
 # Right now, `replay` means no tracing.
 # But we don't have a way of disabling post-processing
 folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace(ARGV)
-postprocess(folder, {})
+postprocess(folder) if mpi_master?

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -83,7 +83,7 @@ end
 # Multiple iprof may run in parallel (for example using ctest),
 # so use a random hex by default
 def mpi_job_id
-  env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
+  @mpi_job_id ||= env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
 end
 
 def mpi_rank_id
@@ -293,7 +293,7 @@ def rename_root_to_human_readable_folder(lttng_output_root)
 
   date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
   path = (0..).each do |i|
-    prefix =  i == 0 ? '' : "_#{i}"
+    prefix = i == 0 ? '' : "_#{i}"
     path = lttng_output_root.sub("--#{mpi_job_id}", "--#{date}#{prefix}")
     begin
       Dir.mkdir(path)
@@ -303,6 +303,7 @@ def rename_root_to_human_readable_folder(lttng_output_root)
       break path
     end
   end
+  LOGGER.debug { "Rename #{lttng_output_root} -> #{path}" }
   File.rename(lttng_output_root, path)
   path
 end
@@ -394,11 +395,11 @@ end
 
 # TODO: Put in option
 # Or env_fetch_first('HOME'),
-THAPI_TMP_FOLDER_ROOT = "/tmp"
+THAPI_TMP_FOLDER_ROOT = '/tmp'
 
 def get_lttng_paths
   #  We launch one daemon per Node
-  #  Hence, the output needs to be prefixed by hostname 
+  #  Hence, the output needs to be prefixed by hostname
   #  so that each MPI local master can write to it
   lttng_output = File.join(THAPI_TMP_FOLDER_ROOT, 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
 
@@ -468,9 +469,10 @@ def trace(usr_argv)
   # before local master stops the lttng session
   local_barier('waiting_for_application_ending')
   return unless mpi_local_master?
-  teardown_lttng(lttng_session_uuid, lttng_home) 
+
+  teardown_lttng(lttng_session_uuid, lttng_home)
   # Preprocess trace
-  preprocess_trace(lttng_output) 
+  preprocess_trace(lttng_output, backends, global_barrier_h)
 end
 
 #    _                                   _
@@ -486,14 +488,13 @@ end
 
 # The postprocess will as much as "per-node" as possible
 # TODO: In the case of replay we need to print to some error if the saved-trace is not valid
-# For now we will rely and the folder-name. 
+# For now we will rely and the folder-name.
 # This is not robust, we should rely on some `metadata` sometime
-
 
 # postprocess_ctf_transformation
 # Handle any processing need to be done after lttng-trace where generated
 
-def preprocess_trace(lttng_output)
+def preprocess_trace(lttng_output, backends, global_barrier_h)
   raise unless mpi_local_master?
 
   if OPTIONS.include?(:trace)
@@ -502,30 +503,27 @@ def preprocess_trace(lttng_output)
     ctf_output = lttng_output
   elsif OPTIONS.include?(:timeline)
     # Write Interval
-    opts = 'to_interval'
-    opts << "--backend #{backends} "
-    ctf_output = File.join(HOME, 'lttng-traces', "thapi_interval--#{mpi_job_id}", Socket.gethostname)
+    opts = 'to_interval '
+    opts << "--backend #{backends.join(',')} "
+    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi_interval--#{mpi_job_id}", Socket.gethostname)
   else
-    opts = 'to_aggreg'
-    opts << "--backend #{backends} "
+    opts = 'to_aggreg '
+    opts << "--backend #{backends.join(',')} "
     # Write Aggreg
-    ctf_output = File.join(HOME, 'lttng-traces', "thapi_aggreg--#{mpi_job_id}", Socket.gethostname)
+    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi_aggreg--#{mpi_job_id}", Socket.gethostname)
   end
 
-  if opts?
+  unless opts.nil?
     opts << "--output #{ctf_output}"
-    cmd = "#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_output}"
-    LOGGER.debug(cmd)
-    exec("lttng destroy #{lttng_session_uuid}")
+    exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_output}")
   end
 
   # Global Barrier
-  global_barrier(global_barrier_h) 
+  global_barrier(global_barrier_h)
 
   # Replace mpi_job_id with a better name
   rename_root_to_human_readable_folder(File.dirname(ctf_output)) if mpi_master?
 end
-
 
 # Handle stuff who need to be done by the master rank
 # postprocess_master
@@ -553,16 +551,17 @@ def postprocess(folder)
     opts << "--display_name_max_size #{OPTIONS[:'max-name-size']} "
     opts << '--display_mode json ' if OPTIONS.include?(:json)
     opts << "--backend #{backends} "
-    opts << "--backend_level #{backend_level}" unless backend_level.empty?
+    opts << "--backend_level #{backend_level} " unless backend_level.empty?
     opts << '--display extended ' if OPTIONS.include?(:extended)
   end
+
+  opts << '--no-muxer ' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
 
   cmd = "#{BINDIR}/babeltrace_thapi #{opts} -- #{folder}"
   LOGGER.debug(cmd)
   IO.popen(cmd) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }
   end
-
 end
 
 #
@@ -596,7 +595,7 @@ parser.on('--[no-]profile', 'Device activities will not be profiled')
 # General Options
 parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
           'Format: backend_name[:backend_level],...',
-          "Default: #{options[:'backend'].join(',')}")
+          "Default: #{options[:backend].join(',')}")
 
 # Analysis
 parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -565,7 +565,7 @@ def global_processing(folder)
     args += ['trace', '--restrict', '--context', '--backend', backends]
   elsif OPTIONS.include?(:timeline)
     raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
-    args += ['timeline' '--backend', backends]
+    args += ['timeline', '--backend', backends]
   else
     args += ['tally']
     args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -498,9 +498,9 @@ def preprocess_trace(lttng_output, backends, global_barrier_h)
   raise unless mpi_local_master?
 
   if OPTIONS.include?(:trace)
-    # Do nothing
+    # Do move to $home
     opts = nil
-    ctf_output = lttng_output
+    ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
   elsif OPTIONS.include?(:timeline)
     # Write Interval
     opts = 'to_interval '
@@ -513,9 +513,12 @@ def preprocess_trace(lttng_output, backends, global_barrier_h)
     ctf_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi_aggreg--#{mpi_job_id}", Socket.gethostname)
   end
 
-  unless opts.nil?
+  if opts
     opts << "--output #{ctf_output}"
     exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_output}")
+  else
+    FileUtils.mkdir_p(File.dirname(ctf_output))
+    FileUtils.mv(lttng_output, ctf_output)
   end
 
   # Global Barrier
@@ -537,12 +540,12 @@ def postprocess(folder)
   backend_level = OPTIONS[:backend].filter { |nl| nl.include?(':') }.join(',')
 
   if OPTIONS.include?(:trace)
-    opts = 'trace'
+    opts = 'trace '
     opts << '--restrict '
     opts << '--context '
     opts << "--backend #{backends} "
   elsif OPTIONS.include?(:timeline)
-    opts = 'timeline'
+    opts = 'timeline '
     opts << "--backend #{backends} "
   else
     opts = 'tally '


### PR DESCRIPTION
This adds some  `on-node` processing. 

Need to add some more options to add flexibility on where to save data and with step / processes to perform.

(Sorry for some typo change, it's rubocopt doing is thing...) 

- Added a `no-muxer` to babeltrace_thapi
- Add this `on-node-processing` concept to xprof. 