### PR TITLE
Better opt

### DIFF
--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -79,4 +79,5 @@ EXTRA_DIST = \
 	gen_babeltrace_emitter.rb \
 	thapi_metadata_tracepoints.tp \
 	command.rb \
-	meta_parameters.rb
+	meta_parameters.rb \
+	optparse_thapi.rb

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -50,10 +50,13 @@ bin_SCRIPTS = \
 version:
 	git describe --abbrev=7 --dirty --always --tags > version || echo $(PACKAGE_VERSION) > version
 
-data_DATA = version
+data_DATA = \
+	version \
+	optparse_thapi.rb
 
 CLEANFILES = \
 	version \
+	optparse_thapi.rb \
 	lttng/tracepoint_gen.h \
 	$(BUILT_SOURCES)
 

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -74,8 +74,8 @@ module BTComponentClassRefinement
     attr_accessor :plugins_path, :cli_v
 
     def add(component_class, name, params: {},
-                      logging_level: BT2::BTLogging.default_level,
-                      initialize_method_data: nil)
+            logging_level: BT2::BTLogging.default_level,
+            initialize_method_data: nil)
 
       @plugins_path << component_class.plugin.path
       @cli_v << "--component #{name}:#{component_class.type.to_s.split('_').last.downcase}.#{component_class.plugin.name}.#{component_class.name}"
@@ -161,22 +161,24 @@ def get_components(names)
       require 'babeltrace_hip_lib' if $options[:backends].include?('hip')
       # I guess need to put it in `babeltrace_energy_lib` at some point?
 
-      $energies={}
-      $event_lambdas["lttng_ust_ze_sampling:gpu_energy"] = lambda { |defi|
-        energy = defi['energy']
-        timestamp = defi['timestamp']
+      $energies = {}
+      if $options[:backends].include?('ze')
+        $event_lambdas['lttng_ust_ze_sampling:gpu_energy'] = lambda { |defi|
+          energy = defi['energy']
+          timestamp = defi['timestamp']
 
-        key = [ defi['hDevice'], defi['domain'] ]
-        previous = $energies[key]
-        $energies[key] = [energy, timestamp]
+          key = [defi['hDevice'], defi['domain']]
+          previous = $energies[key]
+          $energies[key] = [energy, timestamp]
 
-        if previous
-          p_energy, p_timestamp = previous
-          "#{key[0]}:#{key[1]}: #{(energy - p_energy).to_f/(timestamp - p_timestamp)}"
-        else
-          ""
-        end
-      } if $options[:backends].include?('ze')
+          if previous
+            p_energy, p_timestamp = previous
+            "#{key[0]}:#{key[1]}: #{(energy - p_energy).to_f / (timestamp - p_timestamp)}"
+          else
+            ''
+          end
+        }
+      end
 
       f = lambda { |iterator, _|
         iterator.next_messages.each do |m|
@@ -190,7 +192,11 @@ def get_components(names)
           if $options[:context]
             str << " - #{e.stream.trace.get_environment_entry_value_by_name('hostname')}"
             common_context_field = e.get_common_context_field
-            str << " - " << common_context_field.value.collect { |k, v| "#{k}: #{v}" }.join(", ") if common_context_field
+            if common_context_field
+              str << ' - ' << common_context_field.value.collect do |k, v|
+                "#{k}: #{v}"
+              end.join(', ')
+            end
           end
           str << " - #{e.name}: "
           str << (l ? l.call(e.payload_field.value) : e.payload_field.to_s)
@@ -205,7 +211,7 @@ def get_components(names)
 end
 
 def get_and_add_components(graph, names)
-  get_components(names).map do |nc|
+  get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
     case name
@@ -236,9 +242,11 @@ def get_and_add_components(graph, names)
     when 'sink.btx_tally.tally'
       graph.add(comp, 'tally',
                 params: $options_tally.transform_values { |_, v| v })
+    when 'filter.utils.muxer'
+      graph.add(comp, name) unless $options[:'no-muxer']
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
-      graph.add(comp, name.gsub('.','_'))
+      graph.add(comp, name.gsub('.', '_'))
     end
   end
 end
@@ -259,6 +267,10 @@ def common_options(opts)
 
   opts.on('--debug') do |_v|
     $options[:debug] = true
+  end
+
+  opts.on('--no-muxer') do |_v|
+    $options[:'no-muxer'] = true
   end
 
   opts.on('-v', '--version', 'Print the version string') do
@@ -290,15 +302,18 @@ subcommands = {
         $options[:live] = true
       end
     end,
-  'live2aggreg' =>
+  'to_interval' =>
     OptionParser.new do |opts|
-      opts.banner = 'Usage: live2aggreg [OPTIONS]'
+      opts.banner = 'Usage: to_interval [OPTIONS]'
       common_options(opts)
-
-      opts.on('--inputs=INPUTS') do |inputs|
-        $options[:inputs] = [inputs]
+      opts.on('--output=OUTPUT') do |output|
+        $options[:output] = output
       end
-
+    end,
+  'to_aggreg' =>
+    OptionParser.new do |opts|
+      opts.banner = 'Usage: to_aggreg [OPTIONS]'
+      common_options(opts)
       opts.on('--output=OUTPUT') do |output|
         $options[:output] = output
       end
@@ -306,21 +321,6 @@ subcommands = {
   'tally' =>
     OptionParser.new do |opts|
       opts.banner = 'Usage: tally [OPTIONS] trace_directory...'
-      common_options(opts)
-
-      opts.on('--live', 'Enable live display of the trace') do
-        $options[:live] = true
-      end
-
-      $options_tally.each do |k, (t, _)|
-        opts.on("--#{k}=VALUE", t) do |v|
-          $options_tally[k] = [t, v]
-        end
-      end
-    end,
-  'aggreg2tally' =>
-    OptionParser.new do |opts|
-      opts.banner = 'Usage: aggreg2tally [OPTIONS] trace_directory...'
       common_options(opts)
 
       $options_tally.each do |k, (t, _)|
@@ -348,16 +348,28 @@ subcommands[command].order!
 # Fix segfault
 ARGV.uniq!
 
+if $options[:'no-muxer']
+  # We need a metababel plugin to read multiple port who come from the source.
+  # And they need to be first
+  h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 1, 'ze' => 0 }
+  raise if ($options[:backends] & h.filter_map { |k, v| k if v == 0 }).empty?
+
+  $options[:backends] = $options[:backends].sort_by { |k| h[k] }
+end
+
 thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                             'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
                 'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                'sink.btx_timeline.timeline'],
                 'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
-                'live2aggreg' => ['source.ctf.lttng_live', 'filter.utils.muxer', 'filter.intervals.interval',
-                                  'filter.btx_aggreg.aggreg', 'sink.ctf.fs'],
-                'aggreg2tally' => ['source.ctf.fs', 'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'] }
+                'trace_live' => ['source.ctf.lttng_live', 'filter.utils.muxer', 'sink.text.rubypretty'],
+                'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval', 'sink.ctf.fs'],
+                'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
+                                'filter.btx_aggreg.aggreg', 'sink.ctf.fs'] }
 
 graph = BT2::BTGraph.new
+
+command = 'trace_live' if command == 'trace' && $options[:live]
 comp = get_and_add_components(graph, thapi_graph[command])
 connects(graph, comp)
 
@@ -367,7 +379,7 @@ if $options[:debug]
   # puts cli
   puts "babeltrace_thapi: babeltrace2 cli command will be saved in ./#{name}"
   $stdout.flush
-  File.open(name, 'w') { |f| f.write(cli) }
+  File.write(name, cli)
 end
 
 graph.run

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 DATADIR = File.join('@prefix@', 'share')
 $LOAD_PATH.unshift(DATADIR) if File.directory?(DATADIR)
-require 'optparse'
 require 'babeltrace2'
 require 'find'
+require 'optparse_thapi.rb'
 
 module BTComponentClassRefinement
   refine(BT2::BTComponentClass) do

--- a/utils/optparse_thapi.rb
+++ b/utils/optparse_thapi.rb
@@ -1,7 +1,6 @@
 require 'optparse'
 class OptionParserWithDefaultAndValidation < OptionParser
-
-  def initialize()
+  def initialize
     # Dictionary to save the default values passed by `on`
     @defaults = {}
     super
@@ -16,26 +15,39 @@ class OptionParserWithDefaultAndValidation < OptionParser
 
   def define(*opts, &block)
     switch = super
-    # Parse the long name to get the key / name of the option 
+    # Parse the long name to get the key / name of the option
     #   Should be able to get it with some instrospection, no idea how
     # At least `define` already did the split of long, short, and arguments of opts
-    key = switch.long.first.gsub(/^--(?:\[no-\])?/,'').to_sym
+    key = switch.long.first.gsub(/^--(?:\[no-\])?/, '').to_sym
     # Save the default value
     @defaults[key] = @tmp_default unless @tmp_default.nil?
     switch
   end
 
-  def on(*opts, default: nil, allowed:nil, &block)
+  def on(*opts, default: nil, allowed: nil, &block)
     # Save the default, will be used in `refine`.
     @tmp_default = default
-
+    opts << "Values allowed: #{allowed}" unless allowed.nil?
+    # Default can containt Array (or Set).
+    # We cannot use the [a].flatten trick.
+    # So we use the respond_to one
+    #   irb(main):028:0> default = Set[-1,2]
+    #   => #<Set: {-1, 2}>
+    #   irb(main):029:0> [default].flatten.join(',')
+    #   => "#<Set: {-1, 2}>"
+    #   irb(main):030:0> default.respond_to?(:flatten)? default.flatten.join(',') : default
+    #   => "-1,2"
+    opts << "Default: #{default.respond_to?(:flatten) ? default.flatten.join(',') : default}" unless default.nil?
     # Create a new block where
     #   we append our validation layer before the usr block
-    new_block = Proc.new { |a|
-      raise(OptionParser::ParseError, "; Wrong argument: #{a} only #{allowed} allowed") unless allowed.nil? || allowed.include?(a) 
+    new_block = proc do |a|
+      unless allowed.nil? || allowed.include?(a)
+        raise(OptionParser::ParseError,
+              "; Wrong argument: #{a} only #{allowed} allowed")
+      end
+
       block_given? ? block.yield(a) : a
-    }
-    return super(*opts, &new_block)
+    end
+    super(*opts, &new_block)
   end
 end
-

--- a/utils/optparse_thapi.rb
+++ b/utils/optparse_thapi.rb
@@ -1,0 +1,41 @@
+require 'optparse'
+class OptionParserWithDefaultAndValidation < OptionParser
+
+  def initialize()
+    # Dictionary to save the default values passed by `on`
+    @defaults = {}
+    super
+  end
+
+  def parse!(argv = default_argv, into: nil)
+    # Merge the default value with the `into` dict
+    into.merge!(@defaults) unless into.nil?
+    # This will populate the `into` dict (overwriting our default if needed)
+    super
+  end
+
+  def define(*opts, &block)
+    switch = super
+    # Parse the long name to get the key / name of the option 
+    #   Should be able to get it with some instrospection, no idea how
+    # At least `define` already did the split of long, short, and arguments of opts
+    key = switch.long.first.gsub(/^--(?:\[no-\])?/,'').to_sym
+    # Save the default value
+    @defaults[key] = @tmp_default unless @tmp_default.nil?
+    switch
+  end
+
+  def on(*opts, default: nil, allowed:nil, &block)
+    # Save the default, will be used in `refine`.
+    @tmp_default = default
+
+    # Create a new block where
+    #   we append our validation layer before the usr block
+    new_block = Proc.new { |a|
+      raise(OptionParser::ParseError, "; Wrong argument: #{a} only #{allowed} allowed") unless allowed.nil? || allowed.include?(a) 
+      block_given? ? block.yield(a) : a
+    }
+    return super(*opts, &new_block)
+  end
+end
+

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -1,9 +1,23 @@
 #!/usr/bin/env ruby
 
+# We Cannot use "@ .. @" for libdir, bindir, and dataroodir
+# as they will appear as bash "${exec_prefix}/lib"
+# So for now we will rely on them having the default value,
+#  (https://www.gnu.org/software/automake/manual/html_node/Standard-Directory-Variables.html)
+# Will do some gsub + eval if required latter
+EXEC_PREFIX = '@prefix@'
+BINDIR = File.join(EXEC_PREFIX, 'bin')
+LIBDIR = File.join(EXEC_PREFIX, 'lib')
+PKGLIBDIR = File.join(LIBDIR, '@PACKAGE@')
+PREFIX = '@prefix@'
+DATAROOTDIR = File.join(PREFIX, 'share')
+DATADIR = DATAROOTDIR
+
+$LOAD_PATH.unshift(DATADIR) if File.directory?(DATADIR)
 require 'open3'
 require 'fileutils'
 require 'etc'
-require 'optparse'
+require 'optparse_thapi.rb'
 require 'pty'
 require 'digest/md5'
 require 'socket'
@@ -260,20 +274,6 @@ end
 #   | _|_ _|_ ._   _    (_   _ _|_     ._
 #   |_ |_  |_ | | (_|   __) (/_ |_ |_| |_)
 #                  _|                  |
-
-# We Cannot use "@ .. @" for libdir, bindir, and dataroodir
-# as they will appear as bash "${exec_prefix}/lib"
-# So for now we will rely on them having the default value,
-#  (https://www.gnu.org/software/automake/manual/html_node/Standard-Directory-Variables.html)
-# Will do some gsub + eval if required latter
-EXEC_PREFIX = '@prefix@'
-BINDIR = File.join(EXEC_PREFIX, 'bin')
-LIBDIR = File.join(EXEC_PREFIX, 'lib')
-PKGLIBDIR = File.join(LIBDIR, '@PACKAGE@')
-PREFIX = '@prefix@'
-DATAROOTDIR = File.join(PREFIX, 'share')
-DATADIR = DATAROOTDIR
-
 def lttng_session_uuid
   Digest::MD5.hexdigest(lttng_trace_dir_tmp)
 end
@@ -459,7 +459,7 @@ def setup_lttng(backends)
   # Enable backend events
   (backends + ['metadata']).each do |name|
     send("enable_events_#{name}", channel_name,
-         tracing_mode: OPTIONS[:tracing_mode],
+         tracing_mode: OPTIONS[:'tracing-mode'],
          profiling: OPTIONS[:profile])
   end
   exec("lttng start #{lttng_session_uuid}")
@@ -593,19 +593,13 @@ end
 #   |_) _. ._ _ o ._   _    /  |   |
 #   |  (_| | _> | | | (_|   \_ |_ _|_
 #                      _|
-parser = OptionParser.new
-
-options = { tracing_mode: 'default', profile: true, backend: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'],
-            analysis: true,
-            'traced-ranks': Set[-1],
-            'max-name-size': 80,
-            debug: Logger::FATAL }
+parser = OptionParserWithDefaultAndValidation.new
 
 # Tracing
-parser.on('-m', '--tracing-mode=MODE', %w[minimal default full], 'Define the category of events traced')
-parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
+parser.on('-m', '--tracing-mode MODE', 'Define the category of events traced', default: 'default', allowed:  %w[minimal default full])
+parser.on('--traced-ranks RANK', Array, 'Select with MPI rank will be traced.',
           'Use -1 to mean all ranks.',
-          "Default: #{options[:'traced-ranks'].join(',')}") do |ranks|
+          default: Set[-1]) do |ranks|
   ranks.map do |r|
     if r.match?(/^\d+$/)
       r.to_i
@@ -615,13 +609,13 @@ parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
     end
   end.to_set
 end
-parser.on('--[no-]profile', 'Trigger for device activities profiling')
-parser.on('--[no-]analysis', 'Trigger for analysis')
+parser.on('--[no-]profile', 'Trigger for device activities profiling', default: true)
+parser.on('--[no-]analysis', 'Trigger for analysis', default: true)
 
 # General Options
 parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
           'Format: backend_name[:backend_level],...',
-          "Default: #{options[:backend].join(',')}")
+          default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
 
 # Analysis
 parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
@@ -636,16 +630,14 @@ parser.on('-k', '--kernel-verbose',
 parser.on('--max-name-size SIZE',
           OptionParser::DecimalInteger,
           'Maximum size allowed for kernels names.',
-          'Use -1 to mean no limit.',
-          "Default: #{options[:'max-name-size']}")
+          'Use -1 to mean no limit.', default: 80)
 
 parser.on('--metadata', 'Display trace Metadata')
 parser.on('-v', '--version', 'Display THAPI version')
 parser.on('-h', '--help', 'Display this message')
 
 parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
-          "By default the debug level is #{options[:debug]}.",
-          "If LEVEL is omitted the debug level with be set to #{Logger::INFO}") { |d| d || Logger::INFO }
+          "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) { |d| d || Logger::INFO }
 
 def print_help_and_exit(parser, exit_code: 1)
   puts(parser.help)
@@ -662,6 +654,7 @@ end
 # Parsing ARGV
 print_help_and_exit(parser) if ARGV.empty?
 
+options = {}
 begin
   parser.parse!(into: options)
 rescue StandardError => e

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -83,7 +83,7 @@ end
 # Multiple iprof may run in parallel (for example using ctest),
 # so use a random hex by default
 def mpi_job_id
-  env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
+  @mpi_job_id ||= env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
 end
 
 def mpi_rank_id
@@ -106,6 +106,76 @@ def mpi_master?
   mpi_rank_id == 0
 end
 
+#    _                    _
+#   |_ _  |  _|  _  ._   |_) _. _|_ |_
+#   | (_) | (_| (/_ |    |  (_|  |_ | |
+#
+
+# Prefex of the thapi_trace_dir
+def prefix_processed_trace
+  if OPTIONS.include?(:trace) || !OPTIONS[:analysis]
+    ''
+  elsif OPTIONS.include?(:timeline)
+    '_interval'
+  else
+    '_aggreg'
+  end
+end
+
+# THAPI/xprof use multiple folder
+# - lttng_trace_dir_tmp
+#     where the 'raw' lttng trace is saved.
+#     For performance we store in a `tmp` folder.
+#     When "on the fly" analys will be possible, this should not potential OOM
+# - thapi_trace_dir_tmp
+#     Where the "pre-processed / analysed / condensed" trace a saved.
+#     Each nodes need to aggree on a root folder to write into.
+#  - thapi_trace_dir_root
+#     Final directory exposed to the user. The `master rank`  rename the `thapi_trace_dir_tmp`
+#     with a more "friendly" name.
+#
+#  - lttng_home_dir
+#     Home of the lttng daemon
+
+def lttng_trace_dir_tmp
+  File.join('/', 'tmp', "thapi--#{mpi_job_id}", Socket.gethostname)
+end
+
+def thapi_trace_dir_tmp
+  File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{mpi_job_id}",
+            Socket.gethostname)
+end
+
+def lttng_home_dir
+  File.join('/', 'tmp', "lttng_home--#{mpi_job_id}")
+end
+
+def thapi_trace_dir_root
+  raise unless mpi_master?
+
+  @thapi_trace_dir_root ||= begin
+    # Multiple thapi can run concurrently.
+    #   To avoid any race-conditions, we try to MKDIR until we succeed
+
+    # This is solving a consensus for the name,
+    # make it simpler and only allow "rank" per job to do it
+
+    date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
+    (0..).each do |i|
+      prefix = i == 0 ? '' : "_#{i}"
+      thapi_uuid = date + prefix
+      path = File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{thapi_uuid}")
+      begin
+        Dir.mkdir(path)
+      rescue SystemCallError
+        next
+      else
+        break path
+      end
+    end
+  end
+end
+
 #    _
 #   |_)  _. ._ ._ o  _  ._
 #   |_) (_| |  |  | (/_ |
@@ -122,8 +192,8 @@ FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
 SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
 SHARED_GLOBAL_FILESYSTEM = File.join(env_fetch_first('HOME'), FOLDER_JOBID)
 
-# Use a log distribution seem to be a good tradeoff
-# between being nice to the FileSystem (not to many call)
+# Use a log distribution seems to be a good tradeoff
+# between being nice to the FileSystem (not too many calls)
 # but not waiting to much
 def busy_wait(&block)
   (2..).take_while { |i| block.call && sleep(Math.log(i)) }
@@ -146,7 +216,7 @@ def local_barier(name)
 end
 
 # We don't know the total number of ranks
-#   -`PALS_NRANKS` look interesting but is not exported by default
+#   -`PALS_NRANKS` looks interesting but is not exported by default
 #   - We may want to call `MPI_INIT()` our self, but that mean liking against MPI
 #     making it a pain to install / configure THAPI
 # We don't know either how many local masters we have
@@ -154,10 +224,10 @@ end
 #   - We cannot use `PBS_NODEFILE`, as people can request N nodes, but launch <N process
 #
 # At the beginning of the script, each master will create a folder.
-# Then, when hiting the barrier, each local master will remove his file
+# Then, when hitting the barrier, each local master will remove his file
 #  and wait until no more folders exist.
 #
-# This is racy! If one thread exit the barrier before any other enter it,
+# This is racy! If one thread exits the barrier before any other enters it,
 #    this thread will pass the barrier.
 # We rely/We hope, that user will call an MPI_Barrier() && that we do enough work...
 def init_global_barrier
@@ -177,7 +247,7 @@ def global_barrier(f)
   #    then master will clean the folder to be nice to the user
   #
   # Note that `mpi_master` can see the folder empty, and hence remove it
-  #   at the same time as others threads sleep. They will wake up
+  #   at the same time as other threads sleep. They will wake up
   #   and see a deleted folder.
   # Fortunately `count_file` will return -2 for a non exciting folder
   #   hence we test for > 0 and not `!= 0`
@@ -203,6 +273,10 @@ PKGLIBDIR = File.join(LIBDIR, '@PACKAGE@')
 PREFIX = '@prefix@'
 DATAROOTDIR = File.join(PREFIX, 'share')
 DATADIR = DATAROOTDIR
+
+def lttng_session_uuid
+  Digest::MD5.hexdigest(lttng_trace_dir_tmp)
+end
 
 def env_tracers
   # Return the list of backends (used by local master to enable lttng events)
@@ -283,31 +357,7 @@ def launch_usr_bin(env, cmd)
   end
 end
 
-def rename_to_human_readable_folder(lttng_output_root)
-  # Multiple thapi can run concurrently.
-  #   To avoid any race-conditions, we try to MKDIR until we succeed
-
-  # This is solving a consensus for the name,
-  # make it simpler and only allow "rank" per job to do it
-  raise unless mpi_master?
-
-  date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
-  path = (0..).each do |i|
-    prefix =  i == 0 ? '' : "_#{i}"
-    path = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{date}#{prefix}")
-    begin
-      Dir.mkdir(path)
-    rescue SystemCallError
-      next
-    else
-      break path
-    end
-  end
-  File.rename(lttng_output_root, path)
-  path
-end
-
-def enable_events_ze(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_ze(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   case tracing_mode
   when 'minimal'
@@ -340,7 +390,7 @@ def enable_events_ze(lttng_session_uuid, channel_name, tracing_mode: 'default', 
   end
 end
 
-def enable_events_cl(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_cl(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   case tracing_mode
   when 'full'
@@ -370,105 +420,62 @@ def enable_events_cl(lttng_session_uuid, channel_name, tracing_mode: 'default', 
   end
 end
 
-def enable_events_cuda(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_cuda(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_cuda:*")
   exec("#{lttng_enable} lttng_ust_cuda_properties")
   exec("#{lttng_enable} lttng_ust_cuda_profiling:*") if profiling
 end
 
-def enable_events_hip(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_hip(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_hip:*")
 end
 
-def enable_events_omp(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_omp(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_ompt:*target*")
 end
 
-def enable_events_metadata(lttng_session_uuid, channel_name, tracing_mode: 'default', profiling: true)
+def enable_events_metadata(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
   exec("#{lttng_enable} lttng_ust_thapi:*")
 end
 
-def get_lttng_paths
-  #  We launch one daemon per Node
-  #  Hence, the output needs to be prefixed by hostname so that each MPI local master will write into it
-  lttng_output = File.join(env_fetch_first('HOME'), 'lttng-traces', "thapi--#{mpi_job_id}", Socket.gethostname)
+def setup_lttng(backends)
+  raise unless mpi_local_master?
 
-  # Each session will have an UUID.
-  # This will be used to set LLTNG_HOME to a uuid for this run
-  lttng_session_uuid = Digest::MD5.hexdigest(lttng_output)
+  # Spawning the sessiond Daemon will crash
+  #   if LTTNG_HOME doesn't exist
+  FileUtils.mkdir_p(lttng_home_dir)
 
-  # Because $HOME is shared, the sessiond daemon will not be able to get a lock.
-  #   `Error: Could not get lock file $USER/.lttng/lttng-sessiond.lck, another instance is running.`
-  #   We will use the blanket solution of setting LLTNG_HOME waiting for the more granular solution
-  lttng_home = File.join('/', 'tmp', lttng_session_uuid)
-
-  [lttng_output, lttng_session_uuid, lttng_home]
-end
-
-def setup_lttng(lttng_output, lttng_session_uuid, lttng_home, backends)
-  # Daemon will crash if LTTNG_HOME doesn't exist
-  FileUtils.mkdir_p(lttng_home)
-
-  # The daemon will be cleaned in the teardown
   exec('lttng-sessiond --daemonize')
-
-  exec("lttng create #{lttng_session_uuid} -o #{lttng_output}")
+  exec("lttng create #{lttng_session_uuid} -o #{lttng_trace_dir_tmp}")
 
   channel_name = 'blocking-channel'
   exec("lttng enable-channel --userspace --session=#{lttng_session_uuid} --blocking-timeout=inf #{channel_name}")
   exec("lttng add-context    --userspace --session=#{lttng_session_uuid} --channel=#{channel_name} -t vpid -t vtid")
 
+  # Enable backend events
   (backends + ['metadata']).each do |name|
-    send("enable_events_#{name}", lttng_session_uuid, channel_name,
+    send("enable_events_#{name}", channel_name,
          tracing_mode: OPTIONS[:tracing_mode],
          profiling: OPTIONS[:profile])
   end
   exec("lttng start #{lttng_session_uuid}")
 end
 
-def teardown_lttng(lttng_session_uuid, lttng_home)
+def teardown_lttng
   exec("lttng destroy #{lttng_session_uuid}")
-  # Need to kill the sessiond. It's safe because each job has their own
-  #   In theory, opening this file is racy.
-  #   It's possible that the sessiond spawned before writing in the file
-  # In practice, there is so much work between the two. Should be ok
-  pid = File.read(File.join(lttng_home, '.lttng', 'lttng-sessiond.pid')).to_i
+  # Need to kill the sessiond Daemon. It's safe because each job has their own
+  #
+  # In theory, opening the lttng-sessiond.pid file is racy.
+  # It's possible that the sessiond spawned, and didn't yet wrote the file
+  # In practice, there is lot of work between the spawn and the write, so should be ok
+  pid = File.read(File.join(lttng_home_dir, '.lttng', 'lttng-sessiond.pid')).to_i
   LOGGER.info('Killing sessiond')
   Process.kill('SIGKILL', pid)
-end
-
-# Start and Stop lttng
-def trace(usr_argv)
-  # All masters setup a future global barrier
-  global_barrier_h = init_global_barrier if mpi_local_master?
-
-  # Load Tracers and APILoaders Lib
-  backends, h = env_tracers
-
-  # All Need to set the LLTTNG_HOME
-  # so they can have access to the daemon
-  lttng_output, lttng_session_uuid, lttng_home = get_lttng_paths
-  ENV['LTTNG_HOME'] = lttng_home
-  # Only local master spawn LTTNG daemon and start session
-  setup_lttng(lttng_output, lttng_session_uuid, lttng_home, backends) if mpi_local_master?
-  local_barier('waiting_for_lttng_setup')
-  # Launch User Command
-  launch_usr_bin(h, usr_argv)
-
-  # We need to be sure that all the local ranks finished
-  # before local master stops the lttng session
-  local_barier('waiting_for_application_ending')
-  teardown_lttng(lttng_session_uuid, lttng_home) if mpi_local_master?
-
-  # Ensure that all traces have been written so we can post-process them
-  global_barrier(global_barrier_h) if mpi_local_master?
-
-  # Master will move all the folders to a better folder
-  rename_to_human_readable_folder(File.dirname(lttng_output)) if mpi_master?
+  FileUtils.rm_f(lttng_home_dir)
 end
 
 #    _                                   _
@@ -476,41 +483,107 @@ end
 #   |_) (_| |_) (/_ |  |_ | (_| (_ (/_   /_
 #
 
-def last_trace_saved
-  Dir[File.join(env_fetch_first('HOME'), 'lttng-traces', 'thapi--*')].max_by { |f| File.mtime(f) }
-end
-
 # TODO: Use babeltrace_thapi as a LIB not a binary
-def postprocess(folder, _options)
+
+def on_node_processing(_backends, global_barrier_h)
+  raise unless mpi_local_master?
+
+  opts = if OPTIONS.include?(:trace)
+           # Do move to $home
+           nil
+         elsif OPTIONS.include?(:timeline)
+           # Write Interval
+           'to_interval '
+         else
+           'to_aggreg '
+         end
+
+  if opts && OPTIONS[:analysis]
+    opts << "--output #{thapi_trace_dir_tmp}"
+    exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_trace_dir_tmp}")
+    FileUtils.rm_f(lttng_trace_dir_tmp)
+  else
+    FileUtils.mkdir_p(File.dirname(thapi_trace_dir_tmp))
+    FileUtils.mv(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
+  end
+
+  # Global Barrier
+  global_barrier(global_barrier_h)
+
+  # Replace mpi_job_id with a better name
   return unless mpi_master?
 
+  thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
+  FileUtils.mv(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+  thapi_trace_dir_root
+end
+
+# Start, Stop lttng, amd do the on-node analsysis
+def trace_and_on_node_processing(usr_argv)
+  # All masters setup a future global barrier
+  global_barrier_h = init_global_barrier if mpi_local_master?
+
+  # Load Tracers and APILoaders Lib
+  backends, h = env_tracers
+
+  # All ranks need to set the LLTTNG_HOME env
+  # so they can have access to the daemon
+  ENV['LTTNG_HOME'] = lttng_home_dir
+  # Only local master spawn LTTNG daemon and start session
+  setup_lttng(backends) if mpi_local_master?
+  local_barier('waiting_for_lttng_setup')
+  # Launch User Command
+  launch_usr_bin(h, usr_argv)
+
+  # We need to be sure that all the local ranks finished
+  # before local master stops the lttng session
+  local_barier('waiting_for_application_ending')
+  return unless mpi_local_master?
+
+  teardown_lttng
+  # Preprocess trace
+  on_node_processing(backends, global_barrier_h)
+end
+
+def global_processing(folder)
+  raise unless mpi_master?
+
   LOGGER.info { "postprocess #{folder}" }
-  puts("Trace Location #{folder}")
+
   backends = OPTIONS[:'backend-name'].join(',')
   backend_level = OPTIONS[:backend].filter { |nl| nl.include?(':') }.join(',')
 
+  cmdname = "#{BINDIR}/babeltrace_thapi"
+
+  args = []
+
   if OPTIONS.include?(:trace)
-    opts = 'trace'
-    opts << '--restrict '
-    opts << '--context '
-    opts << "--backend #{backends} "
+    if folder.include?('_interval') || folder.include?('_aggreg')
+      raise 'Cannot show the trace of an interval or aggregated trace'
+    end
+
+    args += ['trace', '--restrict', '--context', '--backend', backends]
   elsif OPTIONS.include?(:timeline)
-    opts = 'timeline'
-    opts << "--backend #{backends} "
+    raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
+    args += ['timeline', '--backend', backends]
   else
-    opts = 'tally '
-    opts << '--display_kernel_verbose true ' if OPTIONS.include?(:'kernel-verbose')
-    opts << '--display_metadata true ' if OPTIONS.include?(:metadata)
-    opts << "--display_name_max_size #{OPTIONS[:'max-name-size']} "
-    opts << '--display_mode json ' if OPTIONS.include?(:json)
-    opts << "--backend #{backends} "
-    opts << "--backend_level #{backend_level}" unless backend_level.empty?
-    opts << '--display extended ' if OPTIONS.include?(:extended)
+    args += ['tally']
+    args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')
+    args << '--display_metadata' << 'true' if OPTIONS.include?(:metadata)
+    args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
+    args << '--display_mode' << 'json' if OPTIONS.include?(:json)
+    args << '--backend' << backends
+    args << '--backend_level' << backend_level unless backend_level.empty?
+    args << '--display' << 'extended' if OPTIONS.include?(:extended)
   end
 
-  cmd = "#{BINDIR}/babeltrace_thapi #{opts} -- #{folder}"
-  LOGGER.debug(cmd)
-  IO.popen(cmd) do |stdout, _stdin, _pid|
+  args << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
+
+  args += ['--', folder]
+
+  LOGGER.debug(cmdname)
+  LOGGER.debug(args)
+  IO.popen([cmdname, *args]) do |stdout, _stdin, _pid|
     stdout.each { |line| print line }
   end
 end
@@ -523,6 +596,7 @@ end
 parser = OptionParser.new
 
 options = { tracing_mode: 'default', profile: true, backend: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'],
+            analysis: true,
             'traced-ranks': Set[-1],
             'max-name-size': 80,
             debug: Logger::FATAL }
@@ -541,12 +615,13 @@ parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
     end
   end.to_set
 end
-parser.on('--[no-]profile', 'Device activities will not be profiled')
+parser.on('--[no-]profile', 'Trigger for device activities profiling')
+parser.on('--[no-]analysis', 'Trigger for analysis')
 
 # General Options
 parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
           'Format: backend_name[:backend_level],...',
-          "Default: #{options[:'backend'].join(',')}")
+          "Default: #{options[:backend].join(',')}")
 
 # Analysis
 parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
@@ -600,20 +675,23 @@ OPTIONS = options.freeze
 # Setup Logger
 LOGGER = Logger.new($stdout)
 LOGGER.level = OPTIONS[:debug]
-
 LOGGER.debug(OPTIONS)
-
-# Action
 
 # We don't rely on the Parser-OPT default help, as it doesn't print the footer
 print_help_and_exit(parser, exit_code: 0) if OPTIONS.include?(:help)
-
 if OPTIONS.include?(:version)
   puts(File.read(File.join(DATADIR, 'version')))
   exit(0)
 end
 
+def last_trace_saved
+  Dir[File.join(env_fetch_first('HOME'), 'thapi-traces', 'thapi*')].max_by { |f| File.mtime(f) }
+end
+
 # Right now, `replay` means no tracing.
 # But we don't have a way of disabling post-processing
-folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace(ARGV)
-postprocess(folder, {})
+folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
+if mpi_master?
+  puts("THAPI: Trace Location #{folder}")
+  global_processing(folder) if OPTIONS[:analysis]
+end


### PR DESCRIPTION
```
applenco@x1921c1s2b0n0:~/THAPI/build> ~/THAPI/build/ici/bin/iprof --help
Usage: iprof [options]
    -m, --tracing-mode MODE          Define the category of events traced
                                     Values allowed: ["minimal", "default", "full"]
                                     Default: default
        --traced-ranks RANK          Select with MPI rank will be traced.
                                     Use -1 to mean all ranks.
                                     Default: -1
        --[no-]profile               Trigger for device activities profiling
                                     Default: true
        --[no-]analysis              Trigger for analysis
                                     Default: true
    -b, --backend BACKEND            Select which and how backends' need to handled.
                                     Format: backend_name[:backend_level],...
                                     Default: omp:2,cl:1,ze:1,cuda:1,hip:1
    -r, --replay [PATH]              Replay traces for post-mortem analysis
    -t, --trace                      Pretty print the trace
    -l, --timeline                   Dump a timeline of the trace.
                                     This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer
    -j, --json                       The tally will be dumped as json
    -e, --extended                   The tally will be printed for each Hostname / Process / Thread / Device
    -k, --kernel-verbose             The tally will report kernels execution time with SIMD width and global/local sizes
        --max-name-size SIZE         Maximum size allowed for kernels names.
                                     Use -1 to mean no limit.
                                     Default: 80
        --metadata                   Display trace Metadata
    -v, --version                    Display THAPI version
    -h, --help                       Display this message
        --debug [LEVEL]              Set the Level of debug
                                     If LEVEL is omitted the debug level with be set to 1
                                     Default: 4
                                                      __
For complaints, praises, or bug reports please use: <(o )___
   https://github.com/argonne-lcf/THAPI              ( ._> /
   or send email to {apl,bvideau}@anl.gov             `---'
   ```
   
   The `[no-]` default is kind of confusing. Not sure how to fix it. But now the code is pretty clean and the help too! 