### PR TITLE
Handle sync/barrier with external binary

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -95,18 +95,19 @@ AC_FUNC_ALLOCA
 AC_FUNC_MALLOC
 AC_FUNC_MMAP
 AC_FUNC_REALLOC
-AC_CHECK_FUNCS([atexit clock_gettime ftruncate memmove memset strdup strstr strtoull])
+AC_CHECK_FUNCS([atexit clock_gettime ftruncate memmove memset strdup strstr strtoull strlen strchr])
 
-AC_CONFIG_FILES([Makefile
-                 utils/Makefile
-                 sampling/Makefile
-                 xprof/xprof.rb
-                 opencl/Makefile
-                 ze/Makefile
-                 xprof/Makefile
-                 cuda/Makefile
-                 omp/Makefile
-                 hip/Makefile])
+AC_CONFIG_FILES([
+	Makefile
+	sampling/Makefile
+	opencl/Makefile
+	ze/Makefile
+	cuda/Makefile
+	omp/Makefile
+	hip/Makefile
+	xprof/Makefile
+	utils/Makefile
+])
 AC_CONFIG_FILES([opencl/tracer_opencl.sh], [chmod +x opencl/tracer_opencl.sh])
 AC_CONFIG_FILES([opencl/extract_enqueues], [chmod +x opencl/extract_enqueues])
 AC_CONFIG_FILES([opencl/test_wrapper.sh], [chmod +x opencl/test_wrapper.sh])
@@ -114,9 +115,10 @@ AC_CONFIG_FILES([ze/tracer_ze.sh], [chmod +x ze/tracer_ze.sh])
 AC_CONFIG_FILES([ze/test_wrapper.sh], [chmod +x ze/test_wrapper.sh])
 AC_CONFIG_FILES([cuda/tracer_cuda.sh], [chmod +x cuda/tracer_cuda.sh])
 AC_CONFIG_FILES([cuda/test_wrapper.sh], [chmod +x cuda/test_wrapper.sh])
-AC_CONFIG_FILES([xprof/test_wrapper.sh], [chmod +x xprof/test_wrapper.sh])
-AC_CONFIG_FILES([utils/babeltrace_thapi], [chmod +x utils/babeltrace_thapi])
 AC_CONFIG_FILES([omp/tracer_omp.sh], [chmod +x omp/tracer_omp.sh])
 AC_CONFIG_FILES([hip/tracer_hip.sh], [chmod +x hip/tracer_hip.sh])
 AC_CONFIG_FILES([hip/test_wrapper.sh], [chmod +x hip/test_wrapper.sh])
+AC_CONFIG_FILES([utils/babeltrace_thapi], [chmod +x utils/babeltrace_thapi])
+AC_CONFIG_FILES([xprof/test_wrapper.sh], [chmod +x xprof/test_wrapper.sh])
+AC_CONFIG_FILES([xprof/xprof.rb], [chmod +x xprof/xprof.rb])
 AC_OUTPUT

--- a/utils/xprof_utils.hpp
+++ b/utils/xprof_utils.hpp
@@ -192,9 +192,7 @@ private:
 // ClassName Striping
 template <size_t SuffixLen>
 static inline std::string _strip_event_class_name(const char *str) {
-  const char *p = str + strlen("lttng_");
-  while (*p++ != ':') {
-  }
+  const char *p = strchr(str + strlen("lttng_"), ':') + 1;
   return std::string{p, strlen(p) - SuffixLen};
 }
 

--- a/xprof/Makefile.am
+++ b/xprof/Makefile.am
@@ -6,7 +6,9 @@ else
   WERROR =
 endif
 
-bin_SCRIPTS = iprof
+bin_SCRIPTS = \
+	iprof \
+	sync_daemon_fs
 
 iprof: $(top_builddir)/xprof/xprof.rb
 	cp $(top_builddir)/xprof/xprof.rb $@
@@ -156,16 +158,17 @@ data_DATA = \
 
 EXTRA_DIST = \
 	btx_interval_model.yaml \
-    btx_aggreg_model.yaml \
+	btx_aggreg_model.yaml \
 	btx_timeline_params.yaml \
 	btx_tally_params.yaml \
 	btx_aggreg_params.yaml \
-    interval_model.yaml \
+	interval_model.yaml \
 	$(TRACE_FILES) \
 	tests/tally.dust.erb \
 	perfetto_prunned.proto \
 	interval.c.erb \
-	interval.h.erb
+	interval.h.erb \
+	sync_daemon_fs
 
 CLEANFILES = \
 	iprof \

--- a/xprof/Makefile.am
+++ b/xprof/Makefile.am
@@ -10,9 +10,8 @@ bin_SCRIPTS = \
 	iprof \
 	sync_daemon_fs
 
-iprof: $(top_builddir)/xprof/xprof.rb
-	cp $(top_builddir)/xprof/xprof.rb $@
-	chmod a+x $@
+iprof: xprof.rb
+	cp xprof.rb $@
 
 xprof_utils.hpp: $(top_srcdir)/utils/xprof_utils.hpp
 	cp $< $@

--- a/xprof/sync_daemon_fs
+++ b/xprof/sync_daemon_fs
@@ -1,0 +1,129 @@
+#!/usr/bin/env ruby
+
+SIGRTMIN = 34
+RT_SIGNAL_READY = SIGRTMIN
+RT_SIGNAL_GLOBAL_BARRIER = SIGRTMIN + 1
+RT_SIGNAL_LOCAL_BARRIER = SIGRTMIN + 2
+RT_SIGNAL_FINISH = SIGRTMIN + 3
+
+require 'open3'
+require 'fileutils'
+require 'securerandom'
+require 'etc'
+
+def env_fetch_first(*args, default: nil)
+  ENV.values_at(*args).compact.first || default
+end
+
+def mpi_job_id
+  env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
+end
+
+def mpi_rank_id
+  env_fetch_first('PALS_RANKID', 'PMI_RANK', 'OMPI_COMM_WORLD_RANK', default: 0).to_i
+end
+
+def mpi_local_rank_id
+  env_fetch_first('PALS_LOCAL_RANKID', 'PMI_LOCAL_RANK', 'OMPI_COMM_WORLD_LOCAL_RANK', default: 0).to_i
+end
+
+def mpi_local_size
+  env_fetch_first('PALS_LOCAL_SIZE', 'PMI_LOCAL_SIZE', 'OMPI_COMM_WORLD_LOCAL_SIZE', default: 1).to_i
+end
+
+def mpi_local_master?
+  mpi_local_rank_id == 0
+end
+
+def mpi_master?
+  mpi_rank_id == 0
+end
+
+FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
+SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
+SHARED_GLOBAL_FILESYSTEM = File.join(env_fetch_first('HOME'), FOLDER_JOBID)
+
+def exec(cmd, opts: {}, debug: true)
+  return Open3.capture3(opts, cmd).first unless debug
+
+  LOGGER.info { cmd }
+  LOGGER.debug { opts } unless opts.empty?
+
+  stdout_str, stderr_str, status = Open3.capture3(opts, cmd)
+  raise "#{cmd} failed" unless status.success?
+
+  LOGGER.warn { stderr_str.strip } unless stderr_str.empty?
+  LOGGER.debug { stdout_str.strip } unless stdout_str.empty?
+  stdout_str
+end
+
+# Use a log distribution seem to be a good tradeoff
+# between being nice to the FileSystem (not to many call)
+# but not waiting to much
+def busy_wait(&block)
+  (2..).take_while { |i| block.call && sleep(Math.log(i)) }
+end
+
+def count_file(folder)
+  # \ls to avoid alias. Counter `.` and `..`, so remove them
+  #  Will return -2 for a empty directory
+  stdout_str = exec("\\ls -afq #{folder}", debug: false)
+  stdout_str.lines.size - 2
+end
+
+def init_global_barrier
+  return unless mpi_local_master?
+
+  f = File.join(SHARED_GLOBAL_FILESYSTEM, mpi_rank_id.to_s)
+  FileUtils.mkdir_p(f)
+  f
+end
+
+def global_barrier(f)
+  return unless mpi_local_master?
+
+  # Block until all the process have removed their sentinel,
+  #    then master will clean the folder to be nice to the user
+  #
+  # Note that `mpi_master` can see the folder empty, and hence remove it
+  #   at the same time as others threads sleep. They will wake up
+  #   and see a deleted folder.
+  # Fortunately `count_file` will return -2 for a non exciting folder
+  #   hence we test for > 0 and not `!= 0`
+  FileUtils.rm_rf(f)
+  busy_wait { count_file(SHARED_GLOBAL_FILESYSTEM) > 0 }
+  FileUtils.rm_rf(SHARED_GLOBAL_FILESYSTEM) if mpi_master?
+end
+
+def local_barier(name)
+  folder = File.join(SHARED_LOCAL_FILESYSTEM, name)
+  FileUtils.mkdir_p(File.join(folder, mpi_local_rank_id.to_s))
+  busy_wait { count_file(folder) != mpi_local_size }
+end
+
+# Init global barrier
+global_handle = init_global_barrier
+# Get parent pid
+parent_pid = ARGV[0]
+
+# Set trap
+Signal.trap(RT_SIGNAL_GLOBAL_BARRIER) do
+  global_barrier(global_handle)
+  `kill -#{RT_SIGNAL_READY} #{parent_pid}`
+end
+
+local_barier_count = 0
+Signal.trap(RT_SIGNAL_LOCAL_BARRIER) do
+  local_barier(local_barier_count.to_s)
+  local_barier_count += 1
+  `kill -#{RT_SIGNAL_READY} #{parent_pid}`
+end
+
+Signal.trap(RT_SIGNAL_FINISH) do
+  FileUtils.rm_rf(SHARED_GLOBAL_FILESYSTEM) if mpi_master?
+  FileUtils.rm_rf(SHARED_LOCAL_FILESYSTEM) if mpi_local_master?
+  return
+end
+
+`kill -#{RT_SIGNAL_READY} #{parent_pid}`
+sleep

--- a/xprof/sync_daemon_fs
+++ b/xprof/sync_daemon_fs
@@ -1,43 +1,13 @@
 #!/usr/bin/env ruby
 
-SIGRTMIN = 34
-RT_SIGNAL_READY = SIGRTMIN
-RT_SIGNAL_GLOBAL_BARRIER = SIGRTMIN + 1
-RT_SIGNAL_LOCAL_BARRIER = SIGRTMIN + 2
-RT_SIGNAL_FINISH = SIGRTMIN + 3
+# Cannot use require_relative as iprof is not a rb file
+# Load mpi_* and RT_SIGNAL_*
+load(File.join(__dir__,'iprof'))
 
 require 'open3'
 require 'fileutils'
 require 'securerandom'
 require 'etc'
-
-def env_fetch_first(*args, default: nil)
-  ENV.values_at(*args).compact.first || default
-end
-
-def mpi_job_id
-  env_fetch_first('PALS_APID', 'PMI_JOBID', 'OMPI_MCA_ess_base_jobid', default: SecureRandom.hex)
-end
-
-def mpi_rank_id
-  env_fetch_first('PALS_RANKID', 'PMI_RANK', 'OMPI_COMM_WORLD_RANK', default: 0).to_i
-end
-
-def mpi_local_rank_id
-  env_fetch_first('PALS_LOCAL_RANKID', 'PMI_LOCAL_RANK', 'OMPI_COMM_WORLD_LOCAL_RANK', default: 0).to_i
-end
-
-def mpi_local_size
-  env_fetch_first('PALS_LOCAL_SIZE', 'PMI_LOCAL_SIZE', 'OMPI_COMM_WORLD_LOCAL_SIZE', default: 1).to_i
-end
-
-def mpi_local_master?
-  mpi_local_rank_id == 0
-end
-
-def mpi_master?
-  mpi_rank_id == 0
-end
 
 FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
 SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
@@ -91,19 +61,19 @@ global_handle = nil
 parent_pid = nil
 
 # Set trap
-Signal.trap(RT_SIGNAL_GLOBAL_BARRIER) do
+Signal.trap(Sync_daemon::RT_SIGNAL_GLOBAL_BARRIER) do
   global_barrier(global_handle)
-  Process.kill(RT_SIGNAL_READY, parent_pid)
+  Process.kill(Sync_daemon::RT_SIGNAL_READY, parent_pid)
 end
 
 local_barier_count = 0
-Signal.trap(RT_SIGNAL_LOCAL_BARRIER) do
+Signal.trap(Sync_daemon::RT_SIGNAL_LOCAL_BARRIER) do
   local_barier(local_barier_count.to_s)
   local_barier_count += 1
-  Process.kill(RT_SIGNAL_READY, parent_pid)
+  Process.kill(Sync_daemon::RT_SIGNAL_READY, parent_pid)
 end
 
-Signal.trap(RT_SIGNAL_FINISH) do
+Signal.trap(Sync_daemon::RT_SIGNAL_FINISH) do
   FileUtils.rm_rf(SHARED_GLOBAL_FILESYSTEM) if mpi_master?
   FileUtils.rm_rf(SHARED_LOCAL_FILESYSTEM) if mpi_local_master?
   exit
@@ -112,5 +82,5 @@ end
 # Init global barrier
 global_handle = init_global_barrier
 parent_pid = ARGV[0].to_i
-Process.kill(RT_SIGNAL_READY, parent_pid)
+Process.kill(Sync_daemon::RT_SIGNAL_READY, parent_pid)
 sleep

--- a/xprof/sync_daemon_fs
+++ b/xprof/sync_daemon_fs
@@ -43,20 +43,6 @@ FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
 SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
 SHARED_GLOBAL_FILESYSTEM = File.join(env_fetch_first('HOME'), FOLDER_JOBID)
 
-def exec(cmd, opts: {}, debug: true)
-  return Open3.capture3(opts, cmd).first unless debug
-
-  LOGGER.info { cmd }
-  LOGGER.debug { opts } unless opts.empty?
-
-  stdout_str, stderr_str, status = Open3.capture3(opts, cmd)
-  raise "#{cmd} failed" unless status.success?
-
-  LOGGER.warn { stderr_str.strip } unless stderr_str.empty?
-  LOGGER.debug { stdout_str.strip } unless stdout_str.empty?
-  stdout_str
-end
-
 # Use a log distribution seem to be a good tradeoff
 # between being nice to the FileSystem (not to many call)
 # but not waiting to much
@@ -67,7 +53,7 @@ end
 def count_file(folder)
   # \ls to avoid alias. Counter `.` and `..`, so remove them
   #  Will return -2 for a empty directory
-  stdout_str = exec("\\ls -afq #{folder}", debug: false)
+  stdout_str = Open3.capture3("\\ls -afq #{folder}").first
   stdout_str.lines.size - 2
 end
 
@@ -101,29 +87,30 @@ def local_barier(name)
   busy_wait { count_file(folder) != mpi_local_size }
 end
 
-# Init global barrier
-global_handle = init_global_barrier
-# Get parent pid
-parent_pid = ARGV[0]
+global_handle = nil
+parent_pid = nil
 
 # Set trap
 Signal.trap(RT_SIGNAL_GLOBAL_BARRIER) do
   global_barrier(global_handle)
-  `kill -#{RT_SIGNAL_READY} #{parent_pid}`
+  Process.kill(RT_SIGNAL_READY, parent_pid)
 end
 
 local_barier_count = 0
 Signal.trap(RT_SIGNAL_LOCAL_BARRIER) do
   local_barier(local_barier_count.to_s)
   local_barier_count += 1
-  `kill -#{RT_SIGNAL_READY} #{parent_pid}`
+  Process.kill(RT_SIGNAL_READY, parent_pid)
 end
 
 Signal.trap(RT_SIGNAL_FINISH) do
   FileUtils.rm_rf(SHARED_GLOBAL_FILESYSTEM) if mpi_master?
   FileUtils.rm_rf(SHARED_LOCAL_FILESYSTEM) if mpi_local_master?
-  return
+  exit
 end
 
-`kill -#{RT_SIGNAL_READY} #{parent_pid}`
+# Init global barrier
+global_handle = init_global_barrier
+parent_pid = ARGV[0].to_i
+Process.kill(RT_SIGNAL_READY, parent_pid)
 sleep

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -180,80 +180,49 @@ end
 #   |_)  _. ._ ._ o  _  ._
 #   |_) (_| |  |  | (/_ |
 #
-def count_file(folder)
-  # \ls to avoid alias. Counter `.` and `..`, so remove them
-  #  Will return -2 for a empty directory
-  stdout_str = exec("\\ls -afq #{folder}", debug: false)
-  stdout_str.lines.size - 2
-end
+class Sync_daemon
+  SIGRTMIN = 34
+  RT_SIGNAL_READY = SIGRTMIN
+  RT_SIGNAL_GLOBAL_BARRIER = SIGRTMIN + 1
+  RT_SIGNAL_LOCAL_BARRIER = SIGRTMIN + 2
+  RT_SIGNAL_FINISH = SIGRTMIN + 3
 
-FOLDER_JOBID = File.join('.thapi_lock', mpi_job_id)
-# Put the user name, to avoid permission issue for people sharing nodes
-SHARED_LOCAL_FILESYSTEM = File.join('/', 'dev', 'shm', Etc.getlogin, FOLDER_JOBID)
-SHARED_GLOBAL_FILESYSTEM = File.join(env_fetch_first('HOME'), FOLDER_JOBID)
+  def lazy_exec(&block)
+    return unless in_mpi_env?
 
-# Use a log distribution seems to be a good tradeoff
-# between being nice to the FileSystem (not too many calls)
-# but not waiting to much
-def busy_wait(&block)
-  (2..).take_while { |i| block.call && sleep(Math.log(i)) }
-end
+    Signal.trap(RT_SIGNAL_READY) do
+      return
+    end
+    block.call
+    sleep
+  end
 
-# We know the local size, and the local id
-#   Each process write a file, then we wait until all of them did it
-#
-# We cannot remove the local_path; this can lead to deadlock
-#   One process finish and remove the file,
-#   when another process is sleeping
-# Hence, each local barrier should have a unique name
-def local_barier(name)
-  LOGGER.info { "Local_barier #{name}" }
-  return unless in_mpi_env?
+  def initialize
+    LOGGER.debug { 'Init Sync_daemon' }
+    lazy_exec do
+      @pid = spawn("#{__dir__}/sync_daemon_fs #{Process.pid}")
+    end
+  end
 
-  folder = File.join(SHARED_LOCAL_FILESYSTEM, name)
-  FileUtils.mkdir_p(File.join(folder, mpi_local_rank_id.to_s))
-  busy_wait { count_file(folder) != mpi_local_size }
-end
+  def finalize
+    lazy_exec do
+      `kill -#{RT_SIGNAL_FINISH} #{@pid}`
+    end
+  end
 
-# We don't know the total number of ranks
-#   -`PALS_NRANKS` looks interesting but is not exported by default
-#   - We may want to call `MPI_INIT()` our self, but that mean liking against MPI
-#     making it a pain to install / configure THAPI
-# We don't know either how many local masters we have
-#   - MPI is not required to round-robin process between hosts
-#   - We cannot use `PBS_NODEFILE`, as people can request N nodes, but launch <N process
-#
-# At the beginning of the script, each master will create a folder.
-# Then, when hitting the barrier, each local master will remove his file
-#  and wait until no more folders exist.
-#
-# This is racy! If one thread exits the barrier before any other enters it,
-#    this thread will pass the barrier.
-# We rely/We hope, that user will call an MPI_Barrier() && that we do enough work...
-def init_global_barrier
-  LOGGER.info { 'Init_global_barrier' }
-  return unless in_mpi_env?
+  def local_barrier(name)
+    LOGGER.info { "Local_barrier #{name}" }
+    lazy_exec do
+      `kill -#{RT_SIGNAL_LOCAL_BARRIER} #{@pid}`
+    end
+  end
 
-  f = File.join(SHARED_GLOBAL_FILESYSTEM, mpi_rank_id.to_s)
-  FileUtils.mkdir_p(f)
-  f
-end
-
-def global_barrier(f)
-  LOGGER.info { 'Global_barrier' }
-  return unless in_mpi_env?
-
-  # Block until all the process have removed their sentinel,
-  #    then master will clean the folder to be nice to the user
-  #
-  # Note that `mpi_master` can see the folder empty, and hence remove it
-  #   at the same time as other threads sleep. They will wake up
-  #   and see a deleted folder.
-  # Fortunately `count_file` will return -2 for a non exciting folder
-  #   hence we test for > 0 and not `!= 0`
-  FileUtils.rm_rf(f)
-  busy_wait { count_file(SHARED_GLOBAL_FILESYSTEM) > 0 }
-  FileUtils.rm_rf(SHARED_GLOBAL_FILESYSTEM) if mpi_master?
+  def global_barrier
+    LOGGER.info { 'global_barrier' }
+    lazy_exec do
+      `kill -#{RT_SIGNAL_GLOBAL_BARRIER} #{@pid}`
+    end
+  end
 end
 
 #                        __
@@ -485,7 +454,7 @@ end
 
 # TODO: Use babeltrace_thapi as a LIB not a binary
 
-def on_node_processing(_backends, global_barrier_h)
+def on_node_processing(_backends, syncd)
   raise unless mpi_local_master?
 
   opts = if OPTIONS.include?(:trace)
@@ -508,7 +477,7 @@ def on_node_processing(_backends, global_barrier_h)
   end
 
   # Global Barrier
-  global_barrier(global_barrier_h)
+  syncd.global_barrier
 
   # Replace mpi_job_id with a better name
   return unless mpi_master?
@@ -521,7 +490,7 @@ end
 # Start, Stop lttng, amd do the on-node analsysis
 def trace_and_on_node_processing(usr_argv)
   # All masters setup a future global barrier
-  global_barrier_h = init_global_barrier if mpi_local_master?
+  syncd = Sync_daemon.new
 
   # Load Tracers and APILoaders Lib
   backends, h = env_tracers
@@ -531,18 +500,18 @@ def trace_and_on_node_processing(usr_argv)
   ENV['LTTNG_HOME'] = lttng_home_dir
   # Only local master spawn LTTNG daemon and start session
   setup_lttng(backends) if mpi_local_master?
-  local_barier('waiting_for_lttng_setup')
+  syncd.local_barrier('waiting_for_lttng_setup')
   # Launch User Command
   launch_usr_bin(h, usr_argv)
 
   # We need to be sure that all the local ranks finished
   # before local master stops the lttng session
-  local_barier('waiting_for_application_ending')
+  syncd.local_barrier('waiting_for_application_ending')
   return unless mpi_local_master?
 
   teardown_lttng
   # Preprocess trace
-  on_node_processing(backends, global_barrier_h)
+  on_node_processing(backends, syncd)
 end
 
 def global_processing(folder)
@@ -565,6 +534,7 @@ def global_processing(folder)
     args += ['trace', '--restrict', '--context', '--backend', backends]
   elsif OPTIONS.include?(:timeline)
     raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
+
     args += ['timeline', '--backend', backends]
   else
     args += ['tally']

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -538,6 +538,7 @@ def global_processing(folder)
     args += ['trace', '--restrict', '--context', '--backends', backends]
   elsif OPTIONS.include?(:timeline)
     raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
+
     args += ['timeline', '--backends', backends]
   else
     args += ['tally']
@@ -572,94 +573,93 @@ end
 
 # Avoid load problem
 if __FILE__ == $0
-parser = OptionParserWithDefaultAndValidation.new
+  parser = OptionParserWithDefaultAndValidation.new
 
-# Tracing
-parser.on('-m', '--tracing-mode MODE', 'Define the category of events traced', default: 'default',
-                                                                               allowed: %w[minimal default full])
-parser.on('--traced-ranks RANK', Array, 'Select with MPI rank will be traced.',
-          'Use -1 to mean all ranks.',
-          default: Set[-1]) do |ranks|
-  ranks.map do |r|
-    if r.match?(/^\d+$/)
-      r.to_i
-    else
-      raise(OptionParser::ParseError,
-            "Invalid value (#{r}). Only integer accepted")
-    end
-  end.to_set
-end
-parser.on('--[no-]profile', 'Trigger for device activities profiling', default: true)
-parser.on('--[no-]analysis', 'Trigger for analysis', default: true)
+  # Tracing
+  parser.on('-m', '--tracing-mode MODE', 'Define the category of events traced', default: 'default',
+                                                                                 allowed: %w[minimal default full])
+  parser.on('--traced-ranks RANK', Array, 'Select with MPI rank will be traced.',
+            'Use -1 to mean all ranks.',
+            default: Set[-1]) do |ranks|
+    ranks.map do |r|
+      if r.match?(/^\d+$/)
+        r.to_i
+      else
+        raise(OptionParser::ParseError,
+              "Invalid value (#{r}). Only integer accepted")
+      end
+    end.to_set
+  end
+  parser.on('--[no-]profile', 'Trigger for device activities profiling', default: true)
+  parser.on('--[no-]analysis', 'Trigger for analysis', default: true)
 
-# General Options
-parser.on('-b', '--backends BACKENDS', Array, "Select which and how backends' need to handled.",
-          'Format: backend_name[:backend_level],...',
-          default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
+  # General Options
+  parser.on('-b', '--backends BACKENDS', Array, "Select which and how backends' need to handled.",
+            'Format: backend_name[:backend_level],...',
+            default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
 
-# Analysis
-parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
-parser.on('-t', '--trace', 'Pretty print the trace')
-parser.on('-l', '--timeline', 'Dump a timeline of the trace.',
-          "This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer")
-## Tally Specific Options
-parser.on('-j', '--json', 'The tally will be dumped as json')
-parser.on('-e', '--extended', 'The tally will be printed for each Hostname / Process / Thread / Device')
-parser.on('-k', '--kernel-verbose',
-          'The tally will report kernels execution time with SIMD width and global/local sizes')
-parser.on('--max-name-size SIZE',
-          OptionParser::DecimalInteger,
-          'Maximum size allowed for kernels names.',
-          'Use -1 to mean no limit.', default: 80)
+  # Analysis
+  parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
+  parser.on('-t', '--trace', 'Pretty print the trace')
+  parser.on('-l', '--timeline', 'Dump a timeline of the trace.',
+            "This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer")
+  ## Tally Specific Options
+  parser.on('-j', '--json', 'The tally will be dumped as json')
+  parser.on('-e', '--extended', 'The tally will be printed for each Hostname / Process / Thread / Device')
+  parser.on('-k', '--kernel-verbose',
+            'The tally will report kernels execution time with SIMD width and global/local sizes')
+  parser.on('--max-name-size SIZE',
+            OptionParser::DecimalInteger,
+            'Maximum size allowed for kernels names.',
+            'Use -1 to mean no limit.', default: 80)
 
-parser.on('--metadata', 'Display trace Metadata') do
-  puts File.read(File.join(DATADIR, 'version'))
-  exit
-end
+  parser.on('--metadata', 'Display trace Metadata') do
+    puts File.read(File.join(DATADIR, 'version'))
+    exit
+  end
 
-parser.on('-h', '--help', 'Display this message') { print_help_and_exit(parser, exit_code: 0) }
+  parser.on('-h', '--help', 'Display this message') { print_help_and_exit(parser, exit_code: 0) }
 
-parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
-          "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) { |d| d || Logger::INFO }
+  parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
+            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) { |d| d || Logger::INFO }
 
-def print_help_and_exit(parser, exit_code: 1)
-  puts(parser.help)
-  puts(<<~EOF
-                                                          __
-    For complaints, praises, or bug reports please use: <(o )___
-       https://github.com/argonne-lcf/THAPI              ( ._> /
-       or send email to {apl,bvideau}@anl.gov             `---'
-  EOF
-      )
-  exit(exit_code)
-end
+  def print_help_and_exit(parser, exit_code: 1)
+    puts(parser.help)
+    puts(<<~EOF
+                                                            __
+      For complaints, praises, or bug reports please use: <(o )___
+         https://github.com/argonne-lcf/THAPI              ( ._> /
+         or send email to {apl,bvideau}@anl.gov             `---'
+    EOF
+        )
+    exit(exit_code)
+  end
 
-# Parsing ARGV
-print_help_and_exit(parser) if ARGV.empty?
+  # Parsing ARGV
+  print_help_and_exit(parser) if ARGV.empty?
 
-options = {}
-begin
-  parser.parse!(into: options)
-rescue StandardError => e
-  puts("ERROR: #{e}")
-  print_help_and_exit(parser)
-end
+  options = {}
+  begin
+    parser.parse!(into: options)
+  rescue StandardError => e
+    puts("ERROR: #{e}")
+    print_help_and_exit(parser)
+  end
 
-options[:'backend-names'] = options[:backends].map { |name_level| name_level.split(':').first }
-OPTIONS = options.freeze
+  options[:'backend-names'] = options[:backends].map { |name_level| name_level.split(':').first }
+  OPTIONS = options.freeze
 
-# Setup Logger
-LOGGER = Logger.new($stdout)
-LOGGER.level = OPTIONS[:debug]
-LOGGER.debug(OPTIONS)
+  # Setup Logger
+  LOGGER = Logger.new($stdout)
+  LOGGER.level = OPTIONS[:debug]
+  LOGGER.debug(OPTIONS)
 
-
-# Right now, `replay` means no tracing.
-# But we don't have a way of disabling post-processing
-folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
-if mpi_master?
-  puts("THAPI: Trace Location #{folder}")
-  global_processing(folder) if OPTIONS[:analysis]
-end
+  # Right now, `replay` means no tracing.
+  # But we don't have a way of disabling post-processing
+  folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
+  if mpi_master?
+    puts("THAPI: Trace Location #{folder}")
+    global_processing(folder) if OPTIONS[:analysis]
+  end
 
 end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -471,8 +471,8 @@ def on_node_processing(backends, syncd)
          end
 
   if opts && OPTIONS[:analysis]
-    opts << "--output #{thapi_trace_dir_tmp}"
-    opts << "--backends #{backends.join(',')}"
+    opts << "--output #{thapi_trace_dir_tmp} "
+    opts << "--backends #{backends.join(',')} "
     exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_trace_dir_tmp}")
     FileUtils.rm_f(lttng_trace_dir_tmp)
   else

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -563,105 +563,111 @@ end
 #   |_) _. ._ _ o ._   _    /  |   |
 #   |  (_| | _> | | | (_|   \_ |_ _|_
 #                      _|
-parser = OptionParser.new
-
-options = { tracing_mode: 'default', profile: true, backend: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'],
-            analysis: true,
-            'traced-ranks': Set[-1],
-            'max-name-size': 80,
-            debug: Logger::FATAL }
-
-# Tracing
-parser.on('-m', '--tracing-mode=MODE', %w[minimal default full], 'Define the category of events traced')
-parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
-          'Use -1 to mean all ranks.',
-          "Default: #{options[:'traced-ranks'].join(',')}") do |ranks|
-  ranks.map do |r|
-    if r.match?(/^\d+$/)
-      r.to_i
-    else
-      raise(OptionParser::ParseError,
-            "Invalid value (#{r}). Only integer accepted")
-    end
-  end.to_set
-end
-parser.on('--[no-]profile', 'Trigger for device activities profiling')
-parser.on('--[no-]analysis', 'Trigger for analysis')
-
-# General Options
-parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
-          'Format: backend_name[:backend_level],...',
-          "Default: #{options[:backend].join(',')}")
-
-# Analysis
-parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
-parser.on('-t', '--trace', 'Pretty print the trace')
-parser.on('-l', '--timeline', 'Dump a timeline of the trace.',
-          "This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer")
-## Tally Specific Options
-parser.on('-j', '--json', 'The tally will be dumped as json')
-parser.on('-e', '--extended', 'The tally will be printed for each Hostname / Process / Thread / Device')
-parser.on('-k', '--kernel-verbose',
-          'The tally will report kernels execution time with SIMD width and global/local sizes')
-parser.on('--max-name-size SIZE',
-          OptionParser::DecimalInteger,
-          'Maximum size allowed for kernels names.',
-          'Use -1 to mean no limit.',
-          "Default: #{options[:'max-name-size']}")
-
-parser.on('--metadata', 'Display trace Metadata')
-parser.on('-v', '--version', 'Display THAPI version')
-parser.on('-h', '--help', 'Display this message')
-
-parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
-          "By default the debug level is #{options[:debug]}.",
-          "If LEVEL is omitted the debug level with be set to #{Logger::INFO}") { |d| d || Logger::INFO }
-
-def print_help_and_exit(parser, exit_code: 1)
-  puts(parser.help)
-  puts(<<~EOF
-                                                          __
-    For complaints, praises, or bug reports please use: <(o )___
-       https://github.com/argonne-lcf/THAPI              ( ._> /
-       or send email to {apl,bvideau}@anl.gov             `---'
-  EOF
-      )
-  exit(exit_code)
-end
-
-# Parsing ARGV
-print_help_and_exit(parser) if ARGV.empty?
-
-begin
-  parser.parse!(into: options)
-rescue StandardError => e
-  puts("ERROR: #{e}")
-  print_help_and_exit(parser)
-end
-
-options[:'backend-name'] = options[:backend].map { |name_level| name_level.split(':').first }
-OPTIONS = options.freeze
-
-# Setup Logger
-LOGGER = Logger.new($stdout)
-LOGGER.level = OPTIONS[:debug]
-LOGGER.debug(OPTIONS)
-
-# We don't rely on the Parser-OPT default help, as it doesn't print the footer
-print_help_and_exit(parser, exit_code: 0) if OPTIONS.include?(:help)
-if OPTIONS.include?(:version)
-  puts(File.read(File.join(DATADIR, 'version')))
-  exit(0)
-end
 
 def last_trace_saved
   Dir[File.join(env_fetch_first('HOME'), 'thapi-traces', 'thapi*')].max_by { |f| File.mtime(f) }
 end
 
-# Right now, `replay` means no tracing.
-# But we don't have a way of disabling post-processing
-folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
-if mpi_master?
-  puts("THAPI: Trace Location #{folder}")
-  global_processing(folder) if OPTIONS[:analysis]
+# Avoid load problem
+if __FILE__ == $0
+
+  parser = OptionParser.new
+
+  options = { tracing_mode: 'default', profile: true, backend: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'],
+              analysis: true,
+              'traced-ranks': Set[-1],
+              'max-name-size': 80,
+              debug: Logger::FATAL }
+
+  # Tracing
+  parser.on('-m', '--tracing-mode=MODE', %w[minimal default full], 'Define the category of events traced')
+  parser.on('--traced-ranks=RANK', Array, 'Select with MPI rank will be traced.',
+            'Use -1 to mean all ranks.',
+            "Default: #{options[:'traced-ranks'].join(',')}") do |ranks|
+    ranks.map do |r|
+      if r.match?(/^\d+$/)
+        r.to_i
+      else
+        raise(OptionParser::ParseError,
+              "Invalid value (#{r}). Only integer accepted")
+      end
+    end.to_set
+  end
+  parser.on('--[no-]profile', 'Trigger for device activities profiling')
+  parser.on('--[no-]analysis', 'Trigger for analysis')
+
+  # General Options
+  parser.on('-b', '--backend BACKEND', Array, "Select which and how backends' need to handled.",
+            'Format: backend_name[:backend_level],...',
+            "Default: #{options[:backend].join(',')}")
+
+  # Analysis
+  parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
+  parser.on('-t', '--trace', 'Pretty print the trace')
+  parser.on('-l', '--timeline', 'Dump a timeline of the trace.',
+            "This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer")
+  ## Tally Specific Options
+  parser.on('-j', '--json', 'The tally will be dumped as json')
+  parser.on('-e', '--extended', 'The tally will be printed for each Hostname / Process / Thread / Device')
+  parser.on('-k', '--kernel-verbose',
+            'The tally will report kernels execution time with SIMD width and global/local sizes')
+  parser.on('--max-name-size SIZE',
+            OptionParser::DecimalInteger,
+            'Maximum size allowed for kernels names.',
+            'Use -1 to mean no limit.',
+            "Default: #{options[:'max-name-size']}")
+
+  parser.on('--metadata', 'Display trace Metadata')
+  parser.on('-v', '--version', 'Display THAPI version')
+  parser.on('-h', '--help', 'Display this message')
+
+  parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
+            "By default the debug level is #{options[:debug]}.",
+            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}") { |d| d || Logger::INFO }
+
+  def print_help_and_exit(parser, exit_code: 1)
+    puts(parser.help)
+    puts(<<~EOF
+                                                            __
+      For complaints, praises, or bug reports please use: <(o )___
+         https://github.com/argonne-lcf/THAPI              ( ._> /
+         or send email to {apl,bvideau}@anl.gov             `---'
+    EOF
+        )
+    exit(exit_code)
+  end
+
+  # Parsing ARGV
+  print_help_and_exit(parser) if ARGV.empty?
+
+  begin
+    parser.parse!(into: options)
+  rescue StandardError => e
+    puts("ERROR: #{e}")
+    print_help_and_exit(parser)
+  end
+
+  options[:'backend-name'] = options[:backend].map { |name_level| name_level.split(':').first }
+  OPTIONS = options.freeze
+
+  # Setup Logger
+  LOGGER = Logger.new($stdout)
+  LOGGER.level = OPTIONS[:debug]
+  LOGGER.debug(OPTIONS)
+
+  # We don't rely on the Parser-OPT default help, as it doesn't print the footer
+  print_help_and_exit(parser, exit_code: 0) if OPTIONS.include?(:help)
+  if OPTIONS.include?(:version)
+    puts(File.read(File.join(DATADIR, 'version')))
+    exit(0)
+  end
+
+  # Right now, `replay` means no tracing.
+  # But we don't have a way of disabling post-processing
+  folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
+  if mpi_master?
+    puts("THAPI: Trace Location #{folder}")
+    global_processing(folder) if OPTIONS[:analysis]
+  end
+
 end


### PR DESCRIPTION
Based on an idea on @nscottnichols 

This PR add a new binary (`sync_daemon_fs`) who is responsible of performing 2 operation:
 - A local node barrier
 - A global barrier (more precisely all the "global master == rank 0) wait that all "local master" rank hit the barrier and then continue)
  
The communication is on `signal`, so need to for some loop. 

The end goal is to implement another daemon that will use MPI (for faster and more robust SYNC) using the same API.
Then a compile time, we can choose with daemon to use (the filesystem base one, or the MPI one).
