### PR TITLE
Output

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -278,9 +278,9 @@ end
 def raise_if_command_invalid(command, trace)
   case command
   when 'trace'
-    raise('Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(thapi_metadata(trace)[:type])
+    raise('THAPI Trace: Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(thapi_metadata(trace)[:type])
   when 'timeline'
-    raise('Cannot show the trace of an aggreg trace') if %w[aggreg].include?(thapi_metadata(trace)[:type])
+    raise('THAPi Timeline: Cannot show the trace of an aggreg trace') if %w[aggreg].include?(thapi_metadata(trace)[:type])
   end
 end
 

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -233,7 +233,7 @@ def get_and_add_components(graph, command, names)
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
-      graph.add(comp, name) if need_muxer(command, ARGV.first)
+      graph.add(comp, name) if need_muxer(ARGV.first)
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
       graph.add(comp, name.gsub('.', '_'))
@@ -257,23 +257,13 @@ end
 
 THAPI_METADATA_FILE = 'thapi_metadata.yaml'
 
-def raise_if_command_unvalid(command, trace)
-  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
-  case command
-  when 'trace'
-    raise('Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(y[:type])
-  when 'timeline'
-    raise('Cannot show the trace of an aggreg trace') if %w[aggreg].include?(y[:type])
-  end
-end
-
-def need_muxer(_command, trace)
-  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
-  $options[:muxer] || y[:type] == 'lttng'
+def thapi_metadata(trace)
+  @thapi_metadata ||= {}
+  @thapi_metadata[trace] ||= YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
 end
 
 def modify_metadata(command, trace)
-  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
+  y = thapi_metadata(trace)
   case command
   when 'to_interval'
     y[:type] = 'interval'
@@ -282,8 +272,20 @@ def modify_metadata(command, trace)
   else
     return
   end
-
   File.write(File.join($options[:output], THAPI_METADATA_FILE), y.to_yaml)
+end
+
+def raise_if_command_unvalid(command, trace)
+  case command
+  when 'trace'
+    raise('Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(thapi_metadata(trace)[:type])
+  when 'timeline'
+    raise('Cannot show the trace of an aggreg trace') if %w[aggreg].include?(thapi_metadata(trace)[:type])
+  end
+end
+
+def need_muxer(trace)
+  $options[:muxer] || thapi_metadata(trace)[:type] == 'lttng'
 end
 
 class BabeltraceParserThapi < OptionParserWithDefaultAndValidation
@@ -379,7 +381,7 @@ ARGV.uniq!
 
 raise_if_command_unvalid(command, ARGV.first)
 
-unless need_muxer(command, ARGV.first)
+unless need_muxer(ARGV.first)
   # The first filter of the graph need to read multiple port (aka metababael plugin)
   h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 1, 'ze' => 0 }
   raise if ($options[:backends] & h.filter_map { |k, v| k if v == 0 }).empty?

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -377,6 +377,8 @@ end
 # Fix segfault
 ARGV.uniq!
 
+raise_if_command_unvalid(command, ARGV.first)
+
 unless need_muxer(command, ARGV.first)
   # The first filter of the graph need to read multiple port (aka metababael plugin)
   h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 1, 'ze' => 0 }

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -275,7 +275,7 @@ def modify_metadata(command, trace)
   File.write(File.join($options[:output], THAPI_METADATA_FILE), y.to_yaml)
 end
 
-def raise_if_command_unvalid(command, trace)
+def raise_if_command_invalid(command, trace)
   case command
   when 'trace'
     raise('Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(thapi_metadata(trace)[:type])
@@ -379,7 +379,7 @@ end
 # Fix segfault
 ARGV.uniq!
 
-raise_if_command_unvalid(command, ARGV.first)
+raise_if_command_invalid(command, ARGV.first)
 
 unless need_muxer(ARGV.first)
   # The first filter of the graph need to read multiple port (aka metababael plugin)

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -228,6 +228,9 @@ def get_and_add_components(graph, names)
                           'display_name_max_size' => $options[:'display-name-max-size'],
                           'display_kernel_verbose' => $options[:'display-kernel-verbose'] ? false : true,
                           'backend_levels' => $options[:'backend-levels'].join(',') })
+    when 'sink.btx_timeline.timeline'
+      graph.add(comp, 'timeline',
+                params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
       graph.add(comp, name) if $options[:muxer]
     else
@@ -321,6 +324,7 @@ subcommands = {
   'timeline' =>
     BabeltraceParserThapi.new do |parser|
       parser.banner = 'Usage: babeltrace_thapi timeline [OPTIONS] trace_directory...'
+      parser.on('--output-path PATH', String, default: 'out.pftrace')
     end,
 }
 

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -280,7 +280,7 @@ def raise_if_command_invalid(command, trace)
   when 'trace'
     raise('THAPI Trace: Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(thapi_metadata(trace)[:type])
   when 'timeline'
-    raise('THAPi Timeline: Cannot show the trace of an aggreg trace') if %w[aggreg].include?(thapi_metadata(trace)[:type])
+    raise('THAPi Timeline: Cannot show the timeline of an aggregated trace') if %w[aggreg].include?(thapi_metadata(trace)[:type])
   end
 end
 

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -4,6 +4,7 @@ $LOAD_PATH.unshift(DATADIR) if File.directory?(DATADIR)
 require 'babeltrace2'
 require 'find'
 require 'optparse_thapi'
+require 'yaml'
 
 module BTComponentClassRefinement
   refine(BT2::BTComponentClass) do
@@ -190,7 +191,7 @@ def get_components(names)
   end
 end
 
-def get_and_add_components(graph, names)
+def get_and_add_components(graph, command, names)
   get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
@@ -232,7 +233,7 @@ def get_and_add_components(graph, names)
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
-      graph.add(comp, name) if $options[:muxer]
+      graph.add(comp, name) if need_muxer(command, ARGV.first)
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
       graph.add(comp, name.gsub('.', '_'))
@@ -253,13 +254,45 @@ end
 #   |_) _. ._ _ o ._   _    /  |   |
 #   |  (_| | _> | | | (_|   \_ |_ _|_
 #                      _|
+
+THAPI_METADATA_FILE = 'thapi_metadata.yaml'
+
+def raise_if_command_unvalid(command, trace)
+  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
+  case command
+  when 'trace'
+    raise('Cannot show the trace of an interval or aggregated trace') if %w[interval aggreg].include?(y[:type])
+  when 'timeline'
+    raise('Cannot show the trace of an aggreg trace') if %w[aggreg].include?(y[:type])
+  end
+end
+
+def need_muxer(_command, trace)
+  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
+  $options[:muxer] || y[:type] == 'lttng'
+end
+
+def modify_metadata(command, trace)
+  y = YAML.load_file(File.join(trace, THAPI_METADATA_FILE))
+  case command
+  when 'to_interval'
+    y[:type] = 'interval'
+  when 'to_aggreg'
+    y[:type] = 'aggreg'
+  else
+    return
+  end
+
+  File.write(File.join($options[:output], THAPI_METADATA_FILE), y.to_yaml)
+end
+
 class BabeltraceParserThapi < OptionParserWithDefaultAndValidation
   def initialize
     super
     on('-h', '--help', 'Prints this help') { print_help_and_exit(self, exit_code: 0) }
     on('-b', '--backends BACKENDS', Array, default: %w[omp cl ze cuda hip])
     on('--debug', default: false)
-    on('--[no-]muxer', default: true)
+    on('--[no-]muxer')
     on('-v', '--version', 'Print the version string') do
       puts File.read(File.join(DATADIR, 'version'))
       exit
@@ -344,8 +377,8 @@ end
 # Fix segfault
 ARGV.uniq!
 
-unless $options[:muxer]
-  # The first filter of the grap to read multiple port (aka metababael plugin)
+unless need_muxer(command, ARGV.first)
+  # The first filter of the graph need to read multiple port (aka metababael plugin)
   h = { 'cl' => 1, 'omp' => 1, 'hip' => 0, 'cuda' => 1, 'ze' => 0 }
   raise if ($options[:backends] & h.filter_map { |k, v| k if v == 0 }).empty?
 
@@ -370,7 +403,8 @@ thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.inter
 graph = BT2::BTGraph.new
 
 command = 'trace_live' if command == 'trace' && $options[:live]
-comp = get_and_add_components(graph, thapi_graph[command])
+
+comp = get_and_add_components(graph, command, thapi_graph[command])
 connects(graph, comp)
 
 if $options[:debug]
@@ -383,3 +417,4 @@ if $options[:debug]
 end
 
 graph.run
+modify_metadata(command, ARGV.first)

--- a/xprof/btx_timeline.cpp
+++ b/xprof/btx_timeline.cpp
@@ -35,7 +35,7 @@ struct timeline_dispatch_s {
   std::unordered_map<hp_ddomain_t, perfetto_uuid_t> hp_ddomain2pwrtracks;
   std::unordered_map<hp_dsdev_t, perfetto_uuid_t> hp_dsdev2cpetracks;
   std::unordered_map<hp_dsdev_t, perfetto_uuid_t> hp_dsdev2cpytracks;
-  
+
   perfetto_pruned::Trace trace;
 };
 using timeline_dispatch_t = struct timeline_dispatch_s;
@@ -109,7 +109,7 @@ static perfetto_uuid_t get_frequency_track_uuuid(timeline_dispatch_t *dispatch, 
 }
 static perfetto_uuid_t get_power_track_uuuid(timeline_dispatch_t *dispatch, std::string hostname,
                                              uint64_t process_id, thapi_device_id did, thapi_domain_idx domain) {
-  //Extra leading space in the name field to make GPU Power the first track 
+  //Extra leading space in the name field to make GPU Power the first track
   return get_counter_track_uuuid(dispatch, dispatch->hp_ddomain2pwrtracks, "  GPU Power", hostname, process_id, did, domain);
 }
 
@@ -350,7 +350,7 @@ void btx_finalize_component_callback(void *usr_data) {
   if ( path.empty()) {
 	path = "out.pftrace";
   }
-   
+
   // Write the new address book back to disk.
   std::fstream output(path, std::ios::out | std::ios::trunc | std::ios::binary);
   if (!dispatch->trace.SerializeToOstream(&output))

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -147,7 +147,7 @@ end
 #     Each nodes need to aggree on a root folder to write into.
 #  - thapi_trace_dir_root
 #     Final directory exposed to the user. The `master rank`  rename the `thapi_trace_dir_tmp`
-#     with a more "friendly" name. No required if `analsys-output` is set
+#     with a more "friendly" name. Not required if `analysis-output` is set
 #
 #  - lttng_home_dir
 #     Home of the lttng daemon

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -469,7 +469,11 @@ end
 #
 
 # TODO: Use babeltrace_thapi as a LIB not a binary
-
+# Note: I don't understand `mv` 
+#       File.mv(a, b) will put a into b
+#       FileUtils.rename(a,b) will move a as b, but will may
+#         Invalid cross-device 
+#       So we use `exec(mv -T a b)`, this have the added benefice of logging
 def on_node_processing(backends, syncd)
   raise unless mpi_local_master?
 
@@ -490,9 +494,8 @@ def on_node_processing(backends, syncd)
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
     FileUtils.rm_f(lttng_trace_dir_tmp)
   else
-    LOGGER.info { "mv #{lttng_trace_dir_tmp} #{thapi_trace_dir_tmp}" }
     FileUtils.mkdir_p(File.dirname(thapi_trace_dir_tmp))
-    FileUtils.rename(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
+    exec("mv #{lttng_trace_dir_tmp} #{thapi_trace_dir_tmp}")
   end
 
   # Global Barrier
@@ -503,17 +506,11 @@ def on_node_processing(backends, syncd)
 
   thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
 
-  LOGGER.info do
-    "mv #{File.join(thapi_trace_dir_tmp,
-                    'thapi_metadata.yaml')} #{File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml')}"
-  end
-
   FileUtils.cp(File.join(thapi_trace_dir_tmp, 'thapi_metadata.yaml'),
                File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml'))
 
   unless OPTIONS[:'trace-output']
-    LOGGER.info { "mv #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}" }
-    File.rename(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+    exec("mv -T #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}")
   end
 
   thapi_trace_dir_root

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -125,7 +125,7 @@ end
 #   | (_) | (_| (/_ |    |  (_|  |_ | |
 #
 
-# Prefex of the thapi_trace_dir
+# Prefix of the thapi_trace_dir
 def prefix_processed_trace
   if OPTIONS.include?(:trace) || !OPTIONS[:analysis]
     ''
@@ -146,7 +146,7 @@ end
 #     Each nodes need to aggree on a root folder to write into.
 #  - thapi_trace_dir_root
 #     Final directory exposed to the user. The `master rank`  rename the `thapi_trace_dir_tmp`
-#     with a more "friendly" name.
+#     with a more "friendly" name. No required if `analsys-output` is set
 #
 #  - lttng_home_dir
 #     Home of the lttng daemon
@@ -156,6 +156,8 @@ def lttng_trace_dir_tmp
 end
 
 def thapi_trace_dir_tmp
+  return File.join(OPTIONS[:'trace-output'], Socket.gethostname) if OPTIONS[:'trace-output']
+
   File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{mpi_job_id}",
             Socket.gethostname)
 end
@@ -167,13 +169,14 @@ end
 def thapi_trace_dir_root
   raise unless mpi_master?
 
+  return File.join(OPTIONS[:'trace-output']) if OPTIONS[:'trace-output']
+
   @thapi_trace_dir_root ||= begin
     # Multiple thapi can run concurrently.
     #   To avoid any race-conditions, we try to MKDIR until we succeed
 
     # This is solving a consensus for the name,
     # make it simpler and only allow "rank" per job to do it
-
     date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
     (0..).each do |i|
       prefix = i == 0 ? '' : "_#{i}"
@@ -466,22 +469,24 @@ end
 def on_node_processing(backends, syncd)
   raise unless mpi_local_master?
 
-  opts = if OPTIONS.include?(:trace)
+  type = if OPTIONS.include?(:trace)
            # Do move to $home
            nil
          elsif OPTIONS.include?(:timeline)
            # Write Interval
-           'to_interval '
+           'interval'
          else
-           'to_aggreg '
+           'aggreg'
          end
 
-  if opts && OPTIONS[:analysis]
-    opts << "--output #{thapi_trace_dir_tmp} "
-    opts << "--backends #{backends.join(',')} "
-    exec("#{BINDIR}/babeltrace_thapi #{opts} -- #{lttng_trace_dir_tmp}")
+  if type && OPTIONS[:analysis]
+    opts = ["to_#{type}"]
+    opts << "--output #{thapi_trace_dir_tmp}"
+    opts << "--backends #{backends.join(',')}"
+    exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
     FileUtils.rm_f(lttng_trace_dir_tmp)
   else
+    LOGGER.info { "mv #{lttng_trace_dir_tmp} #{thapi_trace_dir_tmp}" }
     FileUtils.mkdir_p(File.dirname(thapi_trace_dir_tmp))
     FileUtils.mv(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
   end
@@ -493,7 +498,13 @@ def on_node_processing(backends, syncd)
   return unless mpi_master?
 
   thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
-  FileUtils.mv(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+  File.write(File.join(thapi_trace_dir_root, 'thapi_type.txt'), type, mode: 'w')
+
+  unless OPTIONS[:'trace-output']
+    LOGGER.info { "mv #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}" }
+    FileUtils.mv(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+  end
+
   thapi_trace_dir_root
 end
 
@@ -536,16 +547,16 @@ def global_processing(folder)
 
   args = []
 
+  type = File.read(File.join(folder, 'thapi_type.txt'))
+
   if OPTIONS.include?(:trace)
-    if folder.include?('_interval') || folder.include?('_aggreg')
-      raise 'Cannot show the trace of an interval or aggregated trace'
-    end
+    raise 'Cannot show the trace of an interval or aggregated trace' if %w[interval aggreg].include?(type)
 
     args += ['trace', '--restrict', '--context', '--backends', backends]
   elsif OPTIONS.include?(:timeline)
-    raise 'Cannot show the trace of an aggreg trace' if folder.include?('_aggreg')
+    raise 'Cannot show the trace of an aggreg trace' if %w[aggreg].include?(type)
 
-    args += ['timeline', '--backends', backends]
+    args += ['timeline', '--backends', backends, '--output-path', OPTIONS[:timeline]]
   else
     args += ['tally']
     args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')
@@ -557,15 +568,24 @@ def global_processing(folder)
     args << '--display' << 'extended' if OPTIONS.include?(:extended)
   end
 
-  args << '--no-muxer' if folder.include?('thapi_interval') || folder.include?('thapi_aggreg')
+  args << '--no-muxer' if %w[interval aggreg].include?(File.read(File.join(folder, 'thapi_type.txt')))
 
   args += ['--', folder]
 
   LOGGER.debug(cmdname)
   LOGGER.debug(args)
-  IO.popen([cmdname, *args]) do |stdout, _stdin, _pid|
-    stdout.each { |line| print line }
+
+  fo = if OPTIONS[:'analysis-output']
+         File.open(OPTIONS[:'analysis-output'], 'w')
+       else
+         $stdout.dup
+       end
+
+  IO.popen([cmdname, *args]) do |pipe|
+    fo.puts(pipe.readlines)
   end
+
+  fo.close
 end
 
 #
@@ -581,6 +601,15 @@ end
 if __FILE__ == $0
   parser = OptionParserWithDefaultAndValidation.new
 
+  parser.on('--trace-output PATH', 'Define where the ctf trace will be saved',
+            'Default path is something like: $HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss') do |p|
+    raise(OptionParser::ParseError, "#{p} already exists") if File.exist?(p)
+
+    p
+  end
+
+  parser.on('--analysis-output PATH',
+            'Define where the output of the analysis (summary, pretty printing,...) will be saved')
   # Tracing
   parser.on('-m', '--tracing-mode MODE', 'Define the category of events traced', default: 'default',
                                                                                  allowed: %w[minimal default full])
@@ -605,10 +634,14 @@ if __FILE__ == $0
             default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
 
   # Analysis
-  parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis')
+  parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis.',
+            'If PATH is omitted, it will be set to the newest trace in $HOME/thapi-traces/')
   parser.on('-t', '--trace', 'Pretty print the trace')
-  parser.on('-l', '--timeline', 'Dump a timeline of the trace.',
-            "This will create a 'out.pftrace' file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer")
+  parser.on('-l', '--timeline [PATH]', 'Dump a timeline of the trace.',
+            'By default will create at PATH file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer',
+            'if PATH is obmited, `out.pftrace` will be used') do |p|
+              p || 'out.pftrace'
+            end
   ## Tally Specific Options
   parser.on('-j', '--json', 'The tally will be dumped as json')
   parser.on('-e', '--extended', 'The tally will be printed for each Hostname / Process / Thread / Device')
@@ -664,7 +697,7 @@ if __FILE__ == $0
   # But we don't have a way of disabling post-processing
   folder = OPTIONS.include?(:replay) ? OPTIONS[:replay] || last_trace_saved : trace_and_on_node_processing(ARGV)
   if mpi_master?
-    puts("THAPI: Trace Location #{folder}")
+    warn("THAPI: Trace location: #{folder}")
     global_processing(folder) if OPTIONS[:analysis]
   end
 

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -114,11 +114,11 @@ def mpi_local_rank_id
 end
 
 def mpi_local_master?
-  mpi_local_rank_id == 0
+  mpi_local_rank_id.zero?
 end
 
 def mpi_master?
-  mpi_rank_id == 0
+  mpi_rank_id.zero?
 end
 
 #    _                    _
@@ -261,10 +261,6 @@ def lttng_session_uuid
   Digest::MD5.hexdigest(lttng_trace_dir_tmp)
 end
 
-def lttng_session_uuid
-  Digest::MD5.hexdigest(lttng_trace_dir_tmp)
-end
-
 def env_tracers
   # Return the list of backends (used by local master to enable lttng events)
   # and the ENV used by any traced-ranks to preload THAPI tracers
@@ -326,10 +322,10 @@ def launch_usr_bin(env, cmd)
   # Transform list to bash env
   #   prepending to current env if already existing
   #   we don't modify `ENV` direclly to avoid by-construction any side-effect
-  bash_env = env.map do |k, v|
+  bash_env = env.to_h do |k, v|
     v.append(env_fetch_first(k)) if env_fetch_first(k)
     [k, [v].flatten.join(':')]
-  end.to_h
+  end
 
   begin
     PTY.spawn(bash_env, *cmd) do |stdout, _stdin, _pid|
@@ -599,7 +595,7 @@ def last_trace_saved
 end
 
 # Avoid load problem
-if __FILE__ == $0
+if __FILE__ == $PROGRAM_NAME
   parser = OptionParserWithDefaultAndValidation.new
 
   parser.on('--trace-output PATH', 'Define where the ctf trace will be saved',
@@ -618,14 +614,14 @@ if __FILE__ == $0
   parser.on('--traced-ranks RANK', Array, 'Select with MPI rank will be traced.',
             'Use -1 to mean all ranks.',
             default: Set[-1]) do |ranks|
-    ranks.map do |r|
+    ranks.to_set do |r|
       if r.match?(/^\d+$/)
         r.to_i
       else
         raise(OptionParser::ParseError,
               "Invalid value (#{r}). Only integer accepted")
       end
-    end.to_set
+    end
   end
   parser.on('--[no-]profile', 'Trigger for device activities profiling', default: true)
   parser.on('--[no-]analysis', 'Trigger for analysis', default: true)
@@ -662,7 +658,9 @@ if __FILE__ == $0
   parser.on('-h', '--help', 'Display this message') { print_help_and_exit(parser, exit_code: 0) }
 
   parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
-            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) { |d| d || Logger::INFO }
+            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) do |d|
+              d || Logger::INFO
+            end
 
   def print_help_and_exit(parser, exit_code: 1)
     puts(parser.help)

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -637,9 +637,9 @@ if __FILE__ == $0
   parser.on('-r', '--replay [PATH]', 'Replay traces for post-mortem analysis.',
             'If PATH is omitted, it will be set to the newest trace in $HOME/thapi-traces/')
   parser.on('-t', '--trace', 'Pretty print the trace')
-  parser.on('-l', '--timeline [PATH]', 'Dump a timeline of the trace.',
-            'By default will create at PATH file that can be opened in perfetto: https://ui.perfetto.dev/#!/viewer',
-            'if PATH is obmited, `out.pftrace` will be used') do |p|
+  parser.on('-l', '--timeline [PATH]', 'Dump the timeline of the trace to a binary file',
+            'If PATH is obmited it will be set to `out.pftrace`',
+            'Open trace with perfetto: https://ui.perfetto.dev/#!/viewer') do |p|
               p || 'out.pftrace'
             end
   ## Tally Specific Options

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -585,8 +585,9 @@ def global_processing(folder)
   IO.popen([cmdname, *args]) do |pipe|
     fo.puts(pipe.readlines)
   end
-
   fo.close
+  exit(1) unless $?.success?
+
 end
 
 #

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -600,7 +600,7 @@ if __FILE__ == $PROGRAM_NAME
 
   parser.on('--trace-output PATH', 'Define where the ctf trace will be saved',
             'Default path is something like: $THAPI_HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss',
-            '$THAPI_HOME is an env variable, is not set will default to $HOME') do |p|
+            '$THAPI_HOME default to $HOME') do |p|
     raise(OptionParser::ParseError, "#{p} already exists") if File.exist?(p)
 
     p

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -471,8 +471,8 @@ end
 # TODO: Use babeltrace_thapi as a LIB not a binary
 # Note: I don't understand `mv`
 #       File.mv(a, b) will put a into b
-#       FileUtils.rename(a,b) will move a as b, but will may
-#         Invalid cross-device
+#       FileUtils.rename(a,b) will move a as b, but may 
+#         raise Invalid cross-device error.
 #       So we use `exec(mv -T a b)`, this have the added benefice of logging
 def on_node_processing(backends, syncd)
   raise unless mpi_local_master?

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -156,10 +156,14 @@ def lttng_trace_dir_tmp
   File.join('/', 'tmp', "thapi--#{mpi_job_id}", Socket.gethostname)
 end
 
+def thapi_trace_home
+  File.join(env_fetch_first('THAPI_HOME', 'HOME'), 'thapi-traces')
+end
+
 def thapi_trace_dir_tmp
   return File.join(OPTIONS[:'trace-output'], Socket.gethostname) if OPTIONS[:'trace-output']
 
-  File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{mpi_job_id}",
+  File.join(thapi_trace_home, "thapi#{prefix_processed_trace}--#{mpi_job_id}",
             Socket.gethostname)
 end
 
@@ -182,7 +186,7 @@ def thapi_trace_dir_root
     (0..).each do |i|
       prefix = i == 0 ? '' : "_#{i}"
       thapi_uuid = date + prefix
-      path = File.join(env_fetch_first('HOME'), 'thapi-traces', "thapi#{prefix_processed_trace}--#{thapi_uuid}")
+      path = File.join(thapi_trace_home, "thapi#{prefix_processed_trace}--#{thapi_uuid}")
       begin
         Dir.mkdir(path)
       rescue SystemCallError
@@ -469,10 +473,10 @@ end
 #
 
 # TODO: Use babeltrace_thapi as a LIB not a binary
-# Note: I don't understand `mv` 
+# Note: I don't understand `mv`
 #       File.mv(a, b) will put a into b
 #       FileUtils.rename(a,b) will move a as b, but will may
-#         Invalid cross-device 
+#         Invalid cross-device
 #       So we use `exec(mv -T a b)`, this have the added benefice of logging
 def on_node_processing(backends, syncd)
   raise unless mpi_local_master?
@@ -509,9 +513,7 @@ def on_node_processing(backends, syncd)
   FileUtils.cp(File.join(thapi_trace_dir_tmp, 'thapi_metadata.yaml'),
                File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml'))
 
-  unless OPTIONS[:'trace-output']
-    exec("mv -T #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}")
-  end
+  exec("mv -T #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}") unless OPTIONS[:'trace-output']
 
   thapi_trace_dir_root
 end
@@ -593,7 +595,7 @@ end
 #   |  (_| | _> | | | (_|   \_ |_ _|_
 #                      _|
 def last_trace_saved
-  Dir[File.join(env_fetch_first('HOME'), 'thapi-traces', 'thapi*')].max_by { |f| File.mtime(f) }
+  Dir[File.join(thapi_trace_home, 'thapi*')].max_by { |f| File.mtime(f) }
 end
 
 # Avoid load problem
@@ -601,7 +603,8 @@ if __FILE__ == $0
   parser = OptionParserWithDefaultAndValidation.new
 
   parser.on('--trace-output PATH', 'Define where the ctf trace will be saved',
-            'Default path is something like: $HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss') do |p|
+            'Default path is something like: $THAPI_HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss',
+            '$THAPI_HOME is an env variable, is not set will default to $HOME') do |p|
     raise(OptionParser::ParseError, "#{p} already exists") if File.exist?(p)
 
     p

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -587,7 +587,6 @@ def global_processing(folder)
   end
   fo.close
   exit(1) unless $?.success?
-
 end
 
 #

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -24,6 +24,7 @@ require 'socket'
 require 'logger'
 require 'set'
 require 'securerandom'
+require 'yaml'
 
 def exec(cmd, opts: {}, debug: true)
   return Open3.capture3(opts, cmd).first unless debug
@@ -430,8 +431,11 @@ def setup_lttng(backends)
   # Spawning the sessiond Daemon will crash
   #   if LTTNG_HOME doesn't exist
   FileUtils.mkdir_p(lttng_home_dir)
+  FileUtils.mkdir_p(lttng_trace_dir_tmp)
   exec('lttng-sessiond --daemonize')
   exec("lttng create #{lttng_session_uuid} -o #{lttng_trace_dir_tmp}")
+
+  File.write(File.join(lttng_trace_dir_tmp, 'thapi_metadata.yaml'), { type: 'lttng' }.to_yaml)
 
   channel_name = 'blocking-channel'
   exec("lttng enable-channel --userspace --session=#{lttng_session_uuid} --blocking-timeout=inf #{channel_name}")
@@ -488,7 +492,7 @@ def on_node_processing(backends, syncd)
   else
     LOGGER.info { "mv #{lttng_trace_dir_tmp} #{thapi_trace_dir_tmp}" }
     FileUtils.mkdir_p(File.dirname(thapi_trace_dir_tmp))
-    FileUtils.mv(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
+    FileUtils.rename(lttng_trace_dir_tmp, thapi_trace_dir_tmp)
   end
 
   # Global Barrier
@@ -498,11 +502,18 @@ def on_node_processing(backends, syncd)
   return unless mpi_master?
 
   thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
-  File.write(File.join(thapi_trace_dir_root, 'thapi_type.txt'), type, mode: 'w')
+
+  LOGGER.info do
+    "mv #{File.join(thapi_trace_dir_tmp,
+                    'thapi_metadata.yaml')} #{File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml')}"
+  end
+
+  FileUtils.cp(File.join(thapi_trace_dir_tmp, 'thapi_metadata.yaml'),
+               File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml'))
 
   unless OPTIONS[:'trace-output']
     LOGGER.info { "mv #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}" }
-    FileUtils.mv(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
+    File.rename(thapi_trace_dir_tmp_root, thapi_trace_dir_root)
   end
 
   thapi_trace_dir_root
@@ -546,16 +557,9 @@ def global_processing(folder)
   cmdname = "#{BINDIR}/babeltrace_thapi"
 
   args = []
-
-  type = File.read(File.join(folder, 'thapi_type.txt'))
-
   if OPTIONS.include?(:trace)
-    raise 'Cannot show the trace of an interval or aggregated trace' if %w[interval aggreg].include?(type)
-
     args += ['trace', '--restrict', '--context', '--backends', backends]
   elsif OPTIONS.include?(:timeline)
-    raise 'Cannot show the trace of an aggreg trace' if %w[aggreg].include?(type)
-
     args += ['timeline', '--backends', backends, '--output-path', OPTIONS[:timeline]]
   else
     args += ['tally']
@@ -567,8 +571,6 @@ def global_processing(folder)
     args << '--backend_levels' << backend_levels unless backend_levels.empty?
     args << '--display' << 'extended' if OPTIONS.include?(:extended)
   end
-
-  args << '--no-muxer' if %w[interval aggreg].include?(File.read(File.join(folder, 'thapi_type.txt')))
 
   args += ['--', folder]
 

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -600,7 +600,7 @@ if __FILE__ == $PROGRAM_NAME
 
   parser.on('--trace-output PATH', 'Define where the ctf trace will be saved',
             'Default path is something like: $THAPI_HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss',
-            '$THAPI_HOME default to $HOME') do |p|
+            '$THAPI_HOME defaults to $HOME') do |p|
     raise(OptionParser::ParseError, "#{p} already exists") if File.exist?(p)
 
     p


### PR DESCRIPTION
Added `--trace-output` and `--analysis-output`.  (to save the trace, and the output of the analysis into specific file)
Added also a `--timeline [PATH]` so one can change where the timeline will be stored

```
applenco@x1921c0s6b0n0:~/THAPI/build> ./ici/bin/iprof  -l roger.pftrace  sycl-ls
Warning: ONEAPI_DEVICE_SELECTOR environment variable is set to level_zero:gpu.
To see the correct device id, please unset ONEAPI_DEVICE_SELECTOR.

[ext_oneapi_level_zero:gpu:0] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:1] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:2] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:3] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:4] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:5] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
THAPI: Trace location: /home/applenco/thapi-traces/thapi_interval--2024-02-19--21h52m08s
THAPI: Perfetto trace location: roger.pftrace
applenco@x1921c0s6b0n0:~/THAPI/build> ./ici/bin/iprof  -l -- sycl-ls
Warning: ONEAPI_DEVICE_SELECTOR environment variable is set to level_zero:gpu.
To see the correct device id, please unset ONEAPI_DEVICE_SELECTOR.

[ext_oneapi_level_zero:gpu:0] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:1] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:2] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:3] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:4] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
[ext_oneapi_level_zero:gpu:5] Intel(R) Level-Zero, Intel(R) Data Center GPU Max 1550 1.3 [1.3.26241]
THAPI: Trace location: /home/applenco/thapi-traces/thapi_interval--2024-02-19--21h52m23s
THAPI: Perfetto trace location: out.pftrace
```

Note the `--` so `--timline` don't take `sycl-ls` as output. 