### PR TITLE
use ISO8601

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -25,6 +25,7 @@ require 'logger'
 require 'set'
 require 'securerandom'
 require 'yaml'
+require 'date'
 
 def exec(cmd, opts: {}, debug: true)
   return Open3.capture3(opts, cmd).first unless debug

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -174,7 +174,7 @@ def thapi_trace_dir_root
     # This is solving a consensus for the name,
     # make it simpler and only allow "rank" per job to do it
     # Use ISO8601 extended format
-    date = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
+    date = DateTime.now.iso8601
     (0..).each do |i|
       prefix = i == 0 ? '' : "_#{i}"
       thapi_uuid = date + prefix

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -173,8 +173,8 @@ def thapi_trace_dir_root
 
     # This is solving a consensus for the name,
     # make it simpler and only allow "rank" per job to do it
-
-    date = Time.now.strftime('%Y-%m-%d--%Hh%Mm%Ss')
+    # Use ISO8601 extended format
+    date = Time.now.strftime('%Y-%m-%dT%H:%M:%S')
     (0..).each do |i|
       prefix = i == 0 ? '' : "_#{i}"
       thapi_uuid = date + prefix


### PR DESCRIPTION
`https://en.wikipedia.org/wiki/ISO_8601` the `:` make it a little painful but still manageable (no need to escape) 

At least now we will use a standard 🤷🏽 