### PR TITLE
Fix option parsing

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -225,9 +225,9 @@ def get_and_add_components(graph, command, names)
                 params: { 'display' => $options[:display],
                           'name' => $options[:name],
                           'display_mode' => $options[:'display-mode'],
-                          'display_metadata' => $options[:'display-metadata'] ? false : true,
+                          'display_metadata' => $options[:'display-metadata'],
                           'display_name_max_size' => $options[:'display-name-max-size'],
-                          'display_kernel_verbose' => $options[:'display-kernel-verbose'] ? false : true,
+                          'display_kernel_verbose' => $options[:'display-kernel-verbose'],
                           'backend_levels' => $options[:'backend-levels'].join(',') })
     when 'sink.btx_timeline.timeline'
       graph.add(comp, 'timeline',
@@ -351,10 +351,10 @@ subcommands = {
       parser.on('--display TYPE', String, default: 'compact', allowed: %w[compact extented])
       parser.on('--name TYPE', String, default: 'demangle', allowed: %w[demangle mangle])
       parser.on('--display-mode MODE', String, default: 'human', allowed: %w[human json])
-      parser.on('--display-metadata')
+      parser.on('--display-metadata', default: false)
       parser.on('--display-name-max-size SIZE', Integer, default: 80)
       parser.on('--backend-levels SIZE', Array, default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
-      parser.on('--display-kernel-verbose')
+      parser.on('--display-kernel-verbose', default: false)
     end,
   'timeline' =>
     BabeltraceParserThapi.new do |parser|

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -562,6 +562,7 @@ def global_processing(folder)
   else
     args += ['tally']
     args << '--display_kernel_verbose' if OPTIONS.include?(:'kernel-verbose')
+    args << '--display_metadata' if OPTIONS.include?(:metadata)
     args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
     args << '--display_mode' << 'json' if OPTIONS.include?(:json)
     args << '--backends' << backends
@@ -652,6 +653,7 @@ if __FILE__ == $PROGRAM_NAME
             'Maximum size allowed for kernels names.',
             'Use -1 to mean no limit.', default: 80)
 
+  parser.on( '--metadata', 'Display the trace metadata')
   parser.on('-v', '--version', 'Print the Version String') do
     puts File.read(File.join(DATADIR, 'version'))
     exit

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -561,8 +561,7 @@ def global_processing(folder)
     args += ['timeline', '--backends', backends, '--output-path', OPTIONS[:timeline]]
   else
     args += ['tally']
-    args << '--display_kernel_verbose' << 'true' if OPTIONS.include?(:'kernel-verbose')
-    args << '--display_metadata' << 'true' if OPTIONS.include?(:metadata)
+    args << '--display_kernel_verbose' if OPTIONS.include?(:'kernel-verbose')
     args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
     args << '--display_mode' << 'json' if OPTIONS.include?(:json)
     args << '--backends' << backends
@@ -653,11 +652,10 @@ if __FILE__ == $PROGRAM_NAME
             'Maximum size allowed for kernels names.',
             'Use -1 to mean no limit.', default: 80)
 
-  parser.on('--metadata', 'Display trace Metadata') do
+  parser.on('-v', '--version', 'Print the Version String') do
     puts File.read(File.join(DATADIR, 'version'))
     exit
   end
-
   parser.on('-h', '--help', 'Display this message') { print_help_and_exit(parser, exit_code: 0) }
 
   parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',


### PR DESCRIPTION
Due too stupidity (and potentially lack of consistency in naming...) `-k` was passed by default.

Thanks @colleeneb  for the report 

Fixed now:

```
applenco@x4407c1s4b0n0:~/THAPI/build> ./ici/bin/iprof --debug -r
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-03-04T16:19:47+00:00
I, [2024-03-04T17:23:13.389172 #193494]  INFO -- : postprocess /home/applenco/thapi-traces/thapi_aggreg--2024-03-04T16:19:47+00:00
BACKEND_ZE | 1 Hostnames | 1 Processes | 1 Threads |

                               Name |     Time | Time(%) | Calls |  Average |      Min |      Max | Error |
                     zeModuleCreate | 142.43ms |  95.22% |     1 | 142.43ms | 142.43ms | 142.43ms |     0 |
       zeCommandListCreateImmediate |   1.95ms |   1.31% |     2 | 977.04us |  37.96us |   1.92ms |     0 |
      zeCommandListAppendMemoryCopy |   1.11ms |   0.74% |    22 |  50.58us |   6.67us | 608.99us |     0 |
    zeCommandListAppendLaunchKernel |   1.09ms |   0.73% |     1 |   1.09ms |   1.09ms |   1.09ms |     0 |
        zeContextMakeMemoryResident | 783.40us |   0.52% |    10 |  78.34us |  41.44us | 124.14us |     0 |
                          zeMemFree | 668.21us |   0.45% |    11 |  60.75us |  13.04us | 108.18us |     0 |
               zeCommandQueueCreate | 577.29us |   0.39% |     1 | 577.29us | 577.29us | 577.29us |     0 |
             zeEventHostSynchronize | 242.44us |   0.16% |    20 |  12.12us |    115ns |  90.25us |     0 |
                    zeModuleDestroy | 197.16us |   0.13% |     1 | 197.16us | 197.16us | 197.16us |     0 |
                   zeMemAllocDevice | 115.57us |   0.08% |    10 |  11.56us |   5.62us |  28.19us |     0 |
                     zeMemAllocHost | 111.92us |   0.07% |     2 |  55.96us |  51.19us |  60.73us |     0 |
                  zeEventPoolCreate |  61.45us |   0.04% |     1 |  61.45us |  61.45us |  61.45us |     0 |
                      zeEventCreate |  50.92us |   0.03% |    64 | 795.56ns |    281ns |  19.89us |     0 |
                   zeMemAllocShared |  36.73us |   0.02% |     1 |  36.73us |  36.73us |  36.73us |     0 |
                 zeEventPoolDestroy |  34.27us |   0.02% |     1 |  34.27us |  34.27us |  34.27us |     0 |
                   zeEventHostReset |  17.30us |   0.01% |    23 | 752.35ns |    300ns |   3.37us |     0 |
                     zeEventDestroy |  16.64us |   0.01% |    64 | 260.05ns |    147ns |   2.11us |     0 |
              zeDeviceGetSubDevices |  12.40us |   0.01% |    12 |   1.03us |    126ns |   2.98us |     0 |
                    zeKernelDestroy |  12.37us |   0.01% |     2 |   6.19us |   1.57us |  10.80us |     0 |
                        zeDeviceGet |  11.28us |   0.01% |     2 |   5.64us |    887ns |  10.39us |     0 |
                     zeKernelCreate |   7.94us |   0.01% |     2 |   3.97us |   1.20us |   6.75us |     0 |
               zeCommandListDestroy |   7.78us |   0.01% |     2 |   3.89us |   3.53us |   4.25us |     0 |
                    zeContextCreate |   7.23us |   0.00% |     1 |   7.23us |   7.23us |   7.23us |     0 |
           zeModuleGetGlobalPointer |   5.17us |   0.00% |     5 |   1.03us |    497ns |   1.40us |     0 |
              zeCommandQueueDestroy |   2.71us |   0.00% |     1 |   2.71us |   2.71us |   2.71us |     0 |
             zeModuleGetKernelNames |   2.38us |   0.00% |     3 | 793.33ns |    364ns |   1.04us |     0 |
                   zeContextDestroy |   1.67us |   0.00% |     1 |   1.67us |   1.67us |   1.67us |     0 |
               zeKernelSetGroupSize |   1.35us |   0.00% |     1 |   1.35us |   1.35us |   1.35us |     0 |
                             zeInit |   1.19us |   0.00% |     1 |   1.19us |   1.19us |   1.19us |     0 |
zeDriverGetExtensionFunctionAddress |   1.09us |   0.00% |     4 | 363.67ns |    327ns |    390ns |     1 |
                        zeDriverGet |    932ns |   0.00% |     2 | 466.00ns |    189ns |    743ns |     0 |
            zeModuleBuildLogDestroy |    857ns |   0.00% |     1 | 857.00ns |    857ns |    857ns |     0 |
              zeDriverGetApiVersion |    833ns |   0.00% |     1 | 833.00ns |    833ns |    833ns |     0 |
          zeKernelSetIndirectAccess |    817ns |   0.00% |     1 | 817.00ns |    817ns |    817ns |     0 |
                              Total | 149.58ms | 100.00% |   277 |                                      1 |

Device profiling | 1 Hostnames | 1 Processes | 1 Threads | 1 Devices | 1 Subdevices |

                              Name |     Time | Time(%) | Calls |  Average |      Min |      Max |
zeCommandListAppendMemoryCopy(M2D) | 155.20us |  55.08% |    10 |  15.52us |     80ns |  67.28us |
                          main_l30 | 102.88us |  36.51% |     1 | 102.88us | 102.88us | 102.88us |
zeCommandListAppendMemoryCopy(S2M) |  11.68us |   4.15% |     4 |   2.92us |   2.08us |   5.28us |
zeCommandListAppendMemoryCopy(D2H) |   8.88us |   3.15% |     3 |   2.96us |   2.88us |   3.12us |
zeCommandListAppendMemoryCopy(M2M) |   2.80us |   0.99% |     1 |   2.80us |   2.80us |   2.80us |
zeCommandListAppendMemoryCopy(H2D) |    240ns |   0.09% |     3 |  80.00ns |     80ns |     80ns |
zeCommandListAppendMemoryCopy(M2S) |     80ns |   0.03% |     1 |  80.00ns |     80ns |     80ns |
                             Total | 281.76us | 100.00% |    23 |

Explicit memory traffic (BACKEND_ZE) | 1 Hostnames | 1 Processes | 1 Threads |

                              Name |    Byte | Byte(%) | Calls |  Average | Min |     Max |
       zeContextMakeMemoryResident | 26.08MB |  82.74% |    10 |   2.61MB |  8B | 16.78MB |
zeCommandListAppendMemoryCopy(M2D) |  5.44MB |  17.26% |    10 | 543.90kB |  4B |  2.68MB |
zeCommandListAppendMemoryCopy(S2M) |    176B |   0.00% |     4 |   44.00B |  8B |    120B |
zeCommandListAppendMemoryCopy(M2S) |     64B |   0.00% |     1 |   64.00B | 64B |     64B |
zeCommandListAppendMemoryCopy(M2M) |     47B |   0.00% |     1 |   47.00B | 47B |     47B |
zeCommandListAppendMemoryCopy(D2H) |     16B |   0.00% |     3 |    5.33B |  4B |      8B |
zeCommandListAppendMemoryCopy(H2D) |     16B |   0.00% |     3 |    5.33B |  4B |      8B |
                             Total | 31.52MB | 100.00% |    32 |

applenco@x4407c1s4b0n0:~/THAPI/build> ./ici/bin/iprof -k --debug -r
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-03-04T16:19:47+00:00
I, [2024-03-04T17:23:17.843030 #193499]  INFO -- : postprocess /home/applenco/thapi-traces/thapi_aggreg--2024-03-04T16:19:47+00:00
BACKEND_ZE | 1 Hostnames | 1 Processes | 1 Threads |

                               Name |     Time | Time(%) | Calls |  Average |      Min |      Max | Error |
                     zeModuleCreate | 142.43ms |  95.22% |     1 | 142.43ms | 142.43ms | 142.43ms |     0 |
       zeCommandListCreateImmediate |   1.95ms |   1.31% |     2 | 977.04us |  37.96us |   1.92ms |     0 |
      zeCommandListAppendMemoryCopy |   1.11ms |   0.74% |    22 |  50.58us |   6.67us | 608.99us |     0 |
    zeCommandListAppendLaunchKernel |   1.09ms |   0.73% |     1 |   1.09ms |   1.09ms |   1.09ms |     0 |
        zeContextMakeMemoryResident | 783.40us |   0.52% |    10 |  78.34us |  41.44us | 124.14us |     0 |
                          zeMemFree | 668.21us |   0.45% |    11 |  60.75us |  13.04us | 108.18us |     0 |
               zeCommandQueueCreate | 577.29us |   0.39% |     1 | 577.29us | 577.29us | 577.29us |     0 |
             zeEventHostSynchronize | 242.44us |   0.16% |    20 |  12.12us |    115ns |  90.25us |     0 |
                    zeModuleDestroy | 197.16us |   0.13% |     1 | 197.16us | 197.16us | 197.16us |     0 |
                   zeMemAllocDevice | 115.57us |   0.08% |    10 |  11.56us |   5.62us |  28.19us |     0 |
                     zeMemAllocHost | 111.92us |   0.07% |     2 |  55.96us |  51.19us |  60.73us |     0 |
                  zeEventPoolCreate |  61.45us |   0.04% |     1 |  61.45us |  61.45us |  61.45us |     0 |
                      zeEventCreate |  50.92us |   0.03% |    64 | 795.56ns |    281ns |  19.89us |     0 |
                   zeMemAllocShared |  36.73us |   0.02% |     1 |  36.73us |  36.73us |  36.73us |     0 |
                 zeEventPoolDestroy |  34.27us |   0.02% |     1 |  34.27us |  34.27us |  34.27us |     0 |
                   zeEventHostReset |  17.30us |   0.01% |    23 | 752.35ns |    300ns |   3.37us |     0 |
                     zeEventDestroy |  16.64us |   0.01% |    64 | 260.05ns |    147ns |   2.11us |     0 |
              zeDeviceGetSubDevices |  12.40us |   0.01% |    12 |   1.03us |    126ns |   2.98us |     0 |
                    zeKernelDestroy |  12.37us |   0.01% |     2 |   6.19us |   1.57us |  10.80us |     0 |
                        zeDeviceGet |  11.28us |   0.01% |     2 |   5.64us |    887ns |  10.39us |     0 |
                     zeKernelCreate |   7.94us |   0.01% |     2 |   3.97us |   1.20us |   6.75us |     0 |
               zeCommandListDestroy |   7.78us |   0.01% |     2 |   3.89us |   3.53us |   4.25us |     0 |
                    zeContextCreate |   7.23us |   0.00% |     1 |   7.23us |   7.23us |   7.23us |     0 |
           zeModuleGetGlobalPointer |   5.17us |   0.00% |     5 |   1.03us |    497ns |   1.40us |     0 |
              zeCommandQueueDestroy |   2.71us |   0.00% |     1 |   2.71us |   2.71us |   2.71us |     0 |
             zeModuleGetKernelNames |   2.38us |   0.00% |     3 | 793.33ns |    364ns |   1.04us |     0 |
                   zeContextDestroy |   1.67us |   0.00% |     1 |   1.67us |   1.67us |   1.67us |     0 |
               zeKernelSetGroupSize |   1.35us |   0.00% |     1 |   1.35us |   1.35us |   1.35us |     0 |
                             zeInit |   1.19us |   0.00% |     1 |   1.19us |   1.19us |   1.19us |     0 |
zeDriverGetExtensionFunctionAddress |   1.09us |   0.00% |     4 | 363.67ns |    327ns |    390ns |     1 |
                        zeDriverGet |    932ns |   0.00% |     2 | 466.00ns |    189ns |    743ns |     0 |
            zeModuleBuildLogDestroy |    857ns |   0.00% |     1 | 857.00ns |    857ns |    857ns |     0 |
              zeDriverGetApiVersion |    833ns |   0.00% |     1 | 833.00ns |    833ns |    833ns |     0 |
          zeKernelSetIndirectAccess |    817ns |   0.00% |     1 | 817.00ns |    817ns |    817ns |     0 |
                              Total | 149.58ms | 100.00% |   277 |                                      1 |

Device profiling | 1 Hostnames | 1 Processes | 1 Threads | 1 Devices | 1 Subdevices |

                                   Name |     Time | Time(%) | Calls |  Average |      Min |      Max |
     zeCommandListAppendMemoryCopy(M2D) | 155.20us |  55.08% |    10 |  15.52us |     80ns |  67.28us |
main_l30[SIMD32, {224,1,1}, {1024,1,1}] | 102.88us |  36.51% |     1 | 102.88us | 102.88us | 102.88us |
     zeCommandListAppendMemoryCopy(S2M) |  11.68us |   4.15% |     4 |   2.92us |   2.08us |   5.28us |
     zeCommandListAppendMemoryCopy(D2H) |   8.88us |   3.15% |     3 |   2.96us |   2.88us |   3.12us |
     zeCommandListAppendMemoryCopy(M2M) |   2.80us |   0.99% |     1 |   2.80us |   2.80us |   2.80us |
     zeCommandListAppendMemoryCopy(H2D) |    240ns |   0.09% |     3 |  80.00ns |     80ns |     80ns |
     zeCommandListAppendMemoryCopy(M2S) |     80ns |   0.03% |     1 |  80.00ns |     80ns |     80ns |
                                  Total | 281.76us | 100.00% |    23 |

Explicit memory traffic (BACKEND_ZE) | 1 Hostnames | 1 Processes | 1 Threads |

                              Name |    Byte | Byte(%) | Calls |  Average | Min |     Max |
       zeContextMakeMemoryResident | 26.08MB |  82.74% |    10 |   2.61MB |  8B | 16.78MB |
zeCommandListAppendMemoryCopy(M2D) |  5.44MB |  17.26% |    10 | 543.90kB |  4B |  2.68MB |
zeCommandListAppendMemoryCopy(S2M) |    176B |   0.00% |     4 |   44.00B |  8B |    120B |
zeCommandListAppendMemoryCopy(M2S) |     64B |   0.00% |     1 |   64.00B | 64B |     64B |
zeCommandListAppendMemoryCopy(M2M) |     47B |   0.00% |     1 |   47.00B | 47B |     47B |
zeCommandListAppendMemoryCopy(D2H) |     16B |   0.00% |     3 |    5.33B |  4B |      8B |
zeCommandListAppendMemoryCopy(H2D) |     16B |   0.00% |     3 |    5.33B |  4B |      8B |
                             Total | 31.52MB | 100.00% |    32 |
```  

(removed metadata handing in xprof as it was never working... Will put it back later when we will handling the new `metadata.yaml` file) 