### PR TITLE
better error message when plugin not found

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -212,6 +212,7 @@ def get_and_add_components(graph, _command, names)
   get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
+    raise "#{name} plugins was not found" unless comp
     case name
     when 'sink.text.rubypretty'
       graph.add_simple_sink('rubypretty', comp)


### PR DESCRIPTION
For whatever reason, on Sunsopt, the module doesn't add LD_LIBRARY_PATH anymore, and everything relies on rpath.

But the `pkgconfig` was still set so `(PROTOBUF_LIBS)` was founded at configure time, but the plugins was not able to be load.
```
export LD_LIBRARY_PATH=/opt/aurora/23.275.2/spack/gcc/0.6.1/install/linux-sles15-x86_64/gcc-12.2.0/protobuf-3.21.12-twja3abpf3vamx3eb2iz67inuxx7v5v5/lib64:$LD_LIBRARY_PATH
```
Did the trick.

Anyway, improve the error message when one plugin cannot be loaded