### PR TITLE
mpi: always include mpi sync daemon in dist

### DIFF
--- a/xprof/Makefile.am
+++ b/xprof/Makefile.am
@@ -233,6 +233,7 @@ EXTRA_DIST = \
 	perfetto_prunned.proto \
 	interval.c.erb \
 	interval.h.erb \
+	sync_daemon_mpi.c \
 	sync_daemon_fs
 
 CLEANFILES = \


### PR DESCRIPTION
This fixes an issue where sync_daemon_mpi.c is not include in the dist tarball. Regardless of what is available on the machine running make dist, all sources should be included in case MPI is available on the machine the tarball is actually used.