### PR TITLE
Improve Traffic

### DIFF
--- a/cuda/btx_cudainterval_callbacks.cpp
+++ b/cuda/btx_cudainterval_callbacks.cpp
@@ -146,7 +146,7 @@ static void exits_traffic_callback(void *btx_handle, void *usr_data, int64_t ts,
   auto size = state->entry_state.get_data<size_t>(key);
   btx_push_message_lttng_traffic(btx_handle, hostname, vpid, vtid, entry_ts,
                                  BACKEND_CUDA,
-                                 event_class_name_stripped.c_str(), size);
+                                 event_class_name_stripped.c_str(), size, "");
 }
 
 static void profiling_callback(void *btx_handle, void *usr_data, int64_t ts,

--- a/cuda/tests/interval_profiling_cuda_memcpy.bt_text_pretty
+++ b/cuda/tests/interval_profiling_cuda_memcpy.bt_text_pretty
@@ -1,4 +1,4 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 3 }, { name = "cuCtxCreate_v2", dur = 10, err = false }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000020, backend = 3 }, { name = "cuMemcpyHtoD_v2", dur = 20, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000020, backend = 3 }, { name = "cuMemcpyHtoD_v2", size = 400 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000020, backend = 3 }, { name = "cuMemcpyHtoD_v2", size = 400, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000020, backend = 3 }, { name = "cuMemcpyHtoD_v2", dur = 1000000, did = 3, sdid = 3, err = false, metadata = "" }

--- a/omp/btx_ompinterval_callbacks.cpp
+++ b/omp/btx_ompinterval_callbacks.cpp
@@ -53,7 +53,7 @@ static void host_and_traffic_op_callback(void *btx_handle, void *usr_data, int64
     btx_push_message_lttng_host(btx_handle, hostname, vpid, vtid, start_ts.value(), BACKEND_OMP,
                                 op_name.c_str(), (ts - start_ts.value()), err);
     btx_push_message_lttng_traffic(btx_handle, hostname, vpid, vtid, start_ts.value(), BACKEND_OMP,
-                                   op_name.c_str(), bytes);
+                                   op_name.c_str(), bytes, "");
   }
 }
 

--- a/omp/tests/data_op.bt_text_pretty
+++ b/omp/tests/data_op.bt_text_pretty
@@ -1,2 +1,2 @@
 lttng:host: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", dur = 0, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", size = 4 }
+lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", size = 4, metadata = "" }

--- a/omp/tests/data_op_emi.bt_text_pretty
+++ b/omp/tests/data_op_emi.bt_text_pretty
@@ -1,6 +1,6 @@
 lttng:host: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", dur = 1, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", size = 4 }
+lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000000, backend = 5 }, { name = "ompt_target_data_alloc", size = 4, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000002, backend = 5 }, { name = "ompt_target_data_delete", dur = 1, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000002, backend = 5 }, { name = "ompt_target_data_delete", size = 4 }
+lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000002, backend = 5 }, { name = "ompt_target_data_delete", size = 4, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000004, backend = 5 }, { name = "ompt_target_data_associate", dur = 1, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000004, backend = 5 }, { name = "ompt_target_data_associate", size = 4 }
+lttng:traffic: { hostname = "testhost", vpid = 1, vtid = 1, ts = 1704110400000000004, backend = 5 }, { name = "ompt_target_data_associate", size = 4, metadata = "" }

--- a/opencl/btx_clinterval_callbacks.cpp
+++ b/opencl/btx_clinterval_callbacks.cpp
@@ -113,7 +113,7 @@ static void enqueue_exit_callback(void *btx_handle, void *usr_data, int64_t ts,
   auto size = state->entry_state.get_data<size_t>(key);
   btx_push_message_lttng_traffic(btx_handle, hostname, vpid, vtid, entry_ts,
                                  BACKEND_OPENCL,
-                                 event_class_name_stripped.c_str(), size);
+                                 event_class_name_stripped.c_str(), size, "");
 }
 
 static void get_device_ids_exit_callback(void *btx_handle, void *usr_data, int64_t ts,

--- a/opencl/tests/command_queue.bt_text_pretty
+++ b/opencl/tests/command_queue.bt_text_pretty
@@ -1,4 +1,4 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clCreateCommandQueue", dur = 1, err = false }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 2, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 65, did = 10, sdid = 0, err = false, metadata = "" }

--- a/opencl/tests/command_queue_other_thread.bt_text_pretty
+++ b/opencl/tests/command_queue_other_thread.bt_text_pretty
@@ -1,4 +1,4 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 2, ts = 1704110400000000000, backend = 2 }, { name = "clCreateCommandQueue", dur = 1, err = false }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 2, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000002, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 65, did = 10, sdid = 0, err = false, metadata = "" }

--- a/opencl/tests/enqueue_read_buffer_fast.bt_text_pretty
+++ b/opencl/tests/enqueue_read_buffer_fast.bt_text_pretty
@@ -1,3 +1,3 @@
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 10, did = 0, sdid = 0, err = false, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 3, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }

--- a/opencl/tests/interleave_process.bt_text_pretty
+++ b/opencl/tests/interleave_process.bt_text_pretty
@@ -1,6 +1,6 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 4, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 20, vtid = 1, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 4, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 20, vtid = 1, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 20, vtid = 1, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 10, did = 0, sdid = 0, err = false, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 20, vtid = 1, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 20, did = 0, sdid = 0, err = false, metadata = "" }

--- a/opencl/tests/interleave_thread.bt_text_pretty
+++ b/opencl/tests/interleave_thread.bt_text_pretty
@@ -1,6 +1,6 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 4, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 2, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 4, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 2, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 2, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 10, did = 0, sdid = 0, err = false, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 2, ts = 1704110400000000001, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 20, did = 0, sdid = 0, err = false, metadata = "" }

--- a/opencl/tests/results_first.bt_text_pretty
+++ b/opencl/tests/results_first.bt_text_pretty
@@ -1,3 +1,3 @@
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 10, did = 0, sdid = 0, err = false, metadata = "" }
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 3, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }

--- a/opencl/tests/with_error.bt_text_pretty
+++ b/opencl/tests/with_error.bt_text_pretty
@@ -1,3 +1,3 @@
 lttng:host: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 2, err = false }
-lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024 }
+lttng:traffic: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", size = 1024, metadata = "" }
 lttng:device: { hostname = "testhost", vpid = 10, vtid = 1, ts = 1704110400000000000, backend = 2 }, { name = "clEnqueueReadBuffer", dur = 0, did = 0, sdid = 0, err = true, metadata = "" }

--- a/xprof/btx_aggreg_model.yaml
+++ b/xprof/btx_aggreg_model.yaml
@@ -83,6 +83,10 @@
                 :type: integer_unsigned
                 :field_value_range: 64
                 :cast_type: uint64_t
+            - :name: metadata
+              :field_class:
+                :type: string
+                :cast_type: const char*
   - :name: interval
     :event_common_context_field_class:
       :type: structure

--- a/xprof/btx_interval_model.yaml
+++ b/xprof/btx_interval_model.yaml
@@ -89,6 +89,10 @@
                 :type: integer_unsigned
                 :field_value_range: 64
                 :cast_type: uint64_t
+            - :name: metadata
+              :field_class:
+                :type: string
+                :cast_type: const char*
       - :name: lttng:frequency 
         :payload_field_class:
           :type: structure

--- a/xprof/btx_tally.cpp
+++ b/xprof/btx_tally.cpp
@@ -318,13 +318,18 @@ static void aggreg_device_callback(void *btx_handle, void *usr_data, const char 
 static void aggreg_traffic_callback(void *btx_handle, void *usr_data, const char *hostname,
                                     int64_t vpid, uint64_t vtid, const char *name, uint64_t min,
                                     uint64_t max, uint64_t total, uint64_t count,
-                                    uint64_t backend) {
+                                    uint64_t backend, const char *metadata) {
 
   auto *data = static_cast<tally_dispatch_t *>(usr_data);
   const int level = data->backend_levels[backend];
   std::string backend_name(magic_enum::enum_names<backend_t>()[backend]);
   data->traffic_backend_name[level].insert(backend_name);
-  data->traffic[level][{hostname, vpid, vtid, name}] += {total, 0, count, min, max};
+
+  std::string sname{name};
+  const auto name_with_metadata = (data->params->display_kernel_verbose && strlen(metadata) != 0)
+                                      ? sname + "[" + metadata + "]"
+                                      : sname;
+  data->traffic[level][{hostname, vpid, vtid, name_with_metadata}] += {total, 0, count, min, max};
   ;
 }
 

--- a/xprof/tests/aggreg_to_tally.thapi_aggreg_text_pretty
+++ b/xprof/tests/aggreg_to_tally.thapi_aggreg_text_pretty
@@ -1,2 +1,2 @@
  hostname: "testhost", vpid: 10, vtid: 1, name: "clEnqueueReadBuffer", min: 10, max: 10, total: 10, count: 1 - aggreg:host: { backend: 2, err_count: 0 }
-hostname: "testhost", vpid: 10, vtid: 1, name: "clEnqueueReadBuffer", min: 400, max: 400, total: 400, count: 1 - aggreg:traffic: { backend: 2 }
+hostname: "testhost", vpid: 10, vtid: 1, name: "clEnqueueReadBuffer", min: 400, max: 400, total: 400, count: 1 - aggreg:traffic: { backend: 2, metadata: "" }

--- a/xprof/tests/interval_to_aggreg.bt_text_pretty
+++ b/xprof/tests/interval_to_aggreg.bt_text_pretty
@@ -1,2 +1,2 @@
 aggreg:host: { hostname = "testhost", vpid = 10, vtid = 1, name = "clEnqueueReadBuffer", min = 10, max = 100, total = 110, count = 3 }, { backend = 2, err_count = 1 }
-aggreg:traffic: { hostname = "testhost", vpid = 10, vtid = 1, name = "clEnqueueReadBuffer", min = 400, max = 400, total = 400, count = 1 }, { backend = 2 }
+aggreg:traffic: { hostname = "testhost", vpid = 10, vtid = 1, name = "clEnqueueReadBuffer", min = 400, max = 400, total = 400, count = 1 }, { backend = 2, metadata = "" }

--- a/xprof/tests/interval_to_aggreg.thapi_interval_text_pretty
+++ b/xprof/tests/interval_to_aggreg.thapi_interval_text_pretty
@@ -1,4 +1,4 @@
-hostname: "testhost", vpid: 10, vtid: 1, ts: 100, backend: 2 - lttng:traffic: { name: "clEnqueueReadBuffer", size: 400 }
+hostname: "testhost", vpid: 10, vtid: 1, ts: 100, backend: 2 - lttng:traffic: { name: "clEnqueueReadBuffer", size: 400, metadata: "" }
 hostname: "testhost", vpid: 10, vtid: 1, ts: 101, backend: 2 - lttng:host: { name: "clEnqueueReadBuffer", dur: 10, err: false }
 hostname: "testhost", vpid: 10, vtid: 1, ts: 101, backend: 2 - lttng:host: { name: "clEnqueueReadBuffer", dur: 100, err: false }
 hostname: "testhost", vpid: 10, vtid: 1, ts: 101, backend: 2 - lttng:host: { name: "clEnqueueReadBuffer", dur: 10, err: true }

--- a/ze/btx_zeinterval_callbacks.cpp
+++ b/ze/btx_zeinterval_callbacks.cpp
@@ -386,7 +386,7 @@ static void hSignalEvent_eventMemory_2ptr_entry_callback(void *btx_handle, void 
             << memory_location(data, hp, (uintptr_t)dstptr) << ")";
     name = ss_name.str();
   }
-  data->threadToLastLaunchInfo[{hostname, vpid, vtid}] = {hCommandList, name, btx_event_t::COPY,
+  data->threadToLastLaunchInfo[{hostname, vpid, vtid}] = {hCommandList, name, btx_event_t::TRAFFIC,
                                                           btx_additional_info_traffic_t{ts, size}};
 }
 
@@ -407,7 +407,7 @@ static void hSignalEvent_eventMemory_1ptr_entry_callback(void *btx_handle, void 
            << memory_location(data, hp, (uintptr_t)ptr) << ")";
     name = name_s.str();
   }
-  data->threadToLastLaunchInfo[{hostname, vpid, vtid}] = {hCommandList, name, btx_event_t::COPY,
+  data->threadToLastLaunchInfo[{hostname, vpid, vtid}] = {hCommandList, name, btx_event_t::TRAFFIC,
                                                           btx_additional_info_traffic_t{ts, size}};
 }
 
@@ -680,7 +680,7 @@ static void event_profiling_result_callback(void *btx_handle, void *usr_data, in
   {
     std::stringstream ss_metadata;
     if ((type == btx_event_t::KERNEL) && (status == ZE_RESULT_SUCCESS))
-      ss_metadata << std::get<btx_additional_info_kernel_t>(ptr.value()) << ", ";
+      ss_metadata << std::get<btx_additional_info_kernel_t>(ptr) << ", ";
     // Create additional Medatata of the Command Queue
     ss_metadata << "{ordinal: " << commandQueueDesc.ordinal << ", "
                 << "index: " << commandQueueDesc.index << "}";
@@ -689,8 +689,8 @@ static void event_profiling_result_callback(void *btx_handle, void *usr_data, in
   if (!hCommandListIsImmediate)
     data->commandListToEvents[{hostname, vpid, hCommandList}].erase(hEvent);
 
-  if ((type == btx_event_t::COPY) && (status == ZE_RESULT_SUCCESS)) {
-    auto &[ts, size] = std::get<btx_additional_info_traffic_t>(ptr.value());
+  if ((type == btx_event_t::TRAFFIC) && (status == ZE_RESULT_SUCCESS)) {
+    auto &[ts, size] = std::get<btx_additional_info_traffic_t>(ptr);
     btx_push_message_lttng_traffic(btx_handle, hostname, vpid, vtid, ts, BACKEND_ZE,
                                    commandName.c_str(), size, metadata.c_str());
   }

--- a/ze/btx_zeinterval_callbacks.hpp
+++ b/ze/btx_zeinterval_callbacks.hpp
@@ -25,13 +25,25 @@ using btx_kernel_group_size_t = std::tuple<uint32_t, uint32_t, uint32_t>;
 using btx_kernel_desct_t =
     std::tuple<std::string /*ze_kernel_desc_t*/, ze_kernel_properties_t, btx_kernel_group_size_t>;
 
+using btx_traffic_t =
+   std::tuple<int64_t /*ts*/,
+   size_t /*size*/>;
+
+enum class btx_event_t { COPY, KERNEL, OTHER };
+
 using btx_launch_desc_t =
-    std::tuple<ze_command_list_handle_t, std::string /*name*/, std::string /*metadata*/>;
+    std::tuple<ze_command_list_handle_t, std::string /*name*/, std::string /*metadata*/,
+    btx_event_t /* type of enum */,
+     void * /* pointer to additional data */>
+     ;
 using btx_event_desct_t =
     std::tuple<thread_id_t, ze_command_queue_desc_t, ze_command_list_handle_t,
                bool /*hCommandListIsImmediate*/, ze_device_handle_t, std::string /*name*/,
                std::string /*metadata*/, int64_t /*ts born min*/,
-               clock_lttng_device_t /* clock sync pair */>;
+               clock_lttng_device_t /* clock sync pair */,
+	       btx_event_t /* type of enum */,
+	       void * /* pointer to additional data */>;
+
 using btx_command_list_desc_t =
     std::tuple<ze_command_queue_desc_t, ze_device_handle_t, bool /*hCommandListIsImmediate*/>;
 

--- a/ze/btx_zeinterval_callbacks.hpp
+++ b/ze/btx_zeinterval_callbacks.hpp
@@ -26,12 +26,11 @@ using btx_kernel_group_size_t = std::tuple<uint32_t, uint32_t, uint32_t>;
 using btx_kernel_desct_t =
     std::tuple<std::string /*ze_kernel_desc_t*/, ze_kernel_properties_t, btx_kernel_group_size_t>;
 
+enum class btx_event_t { TRAFFIC, KERNEL, OTHER };
 using btx_additional_info_traffic_t = std::tuple<int64_t /*ts*/, size_t /*size*/>;
 using btx_additional_info_kernel_t = std::string /*metadata*/;
-
 using btx_additional_info =
-    std::optional<std::variant<btx_additional_info_traffic_t, btx_additional_info_kernel_t>>;
-enum class btx_event_t { COPY, KERNEL, OTHER };
+    std::variant<std::monostate, btx_additional_info_traffic_t, btx_additional_info_kernel_t>;
 
 using btx_launch_desc_t =
     std::tuple<ze_command_list_handle_t, std::string /*name*/, btx_event_t /* type of enum */,

--- a/ze/btx_zeinterval_callbacks.hpp
+++ b/ze/btx_zeinterval_callbacks.hpp
@@ -8,6 +8,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <variant>
 #include <vector>
 
 typedef std::tuple<hostname_t, process_id_t, ze_event_handle_t> hp_event_t;
@@ -25,24 +26,23 @@ using btx_kernel_group_size_t = std::tuple<uint32_t, uint32_t, uint32_t>;
 using btx_kernel_desct_t =
     std::tuple<std::string /*ze_kernel_desc_t*/, ze_kernel_properties_t, btx_kernel_group_size_t>;
 
-using btx_traffic_t =
-   std::tuple<int64_t /*ts*/,
-   size_t /*size*/>;
+using btx_additional_info_traffic_t = std::tuple<int64_t /*ts*/, size_t /*size*/>;
+using btx_additional_info_kernel_t = std::string /*metadata*/;
 
+using btx_additional_info =
+    std::optional<std::variant<btx_additional_info_traffic_t, btx_additional_info_kernel_t>>;
 enum class btx_event_t { COPY, KERNEL, OTHER };
 
 using btx_launch_desc_t =
-    std::tuple<ze_command_list_handle_t, std::string /*name*/, std::string /*metadata*/,
-    btx_event_t /* type of enum */,
-     void * /* pointer to additional data */>
-     ;
+    std::tuple<ze_command_list_handle_t, std::string /*name*/, btx_event_t /* type of enum */,
+               btx_additional_info /* additional data */>;
+
 using btx_event_desct_t =
     std::tuple<thread_id_t, ze_command_queue_desc_t, ze_command_list_handle_t,
                bool /*hCommandListIsImmediate*/, ze_device_handle_t, std::string /*name*/,
-               std::string /*metadata*/, int64_t /*ts born min*/,
-               clock_lttng_device_t /* clock sync pair */,
-	       btx_event_t /* type of enum */,
-	       void * /* pointer to additional data */>;
+               int64_t /*ts born min*/, clock_lttng_device_t /* clock sync pair */,
+               btx_event_t /* type of enum */,
+               btx_additional_info /* pointer to additional data */>;
 
 using btx_command_list_desc_t =
     std::tuple<ze_command_queue_desc_t, ze_device_handle_t, bool /*hCommandListIsImmediate*/>;
@@ -66,7 +66,7 @@ struct data_s {
   std::unordered_map<hp_t, memory_interval_t> rangeset_memory_device;
   std::unordered_map<hp_t, memory_interval_t> rangeset_memory_host;
   std::unordered_map<hp_t, memory_interval_t> rangeset_memory_shared;
-  std::unordered_map<hpt_t, std::unordered_map<hp_t, memory_interval_t>*> rangeset_tmp;
+  std::unordered_map<hpt_t, std::unordered_map<hp_t, memory_interval_t> *> rangeset_tmp;
 
   std::unordered_map<hp_device_t, ze_device_properties_t> device_property;
   std::unordered_map<hp_device_t, thapi_device_id> subdevice_parent;

--- a/ze/btx_zematching_model.yaml
+++ b/ze/btx_zematching_model.yaml
@@ -152,6 +152,13 @@
       :type: structure
       :members:
       - :name: ^size$
+  - :set_id: eventMemory_without_hSignalEvent_exit
+    :domain: n = eventMemory_without_hSignalEvent_entry.map { |b| b.name.sub("_entry","_exit") }; exits.filter { |a| n.include?(a.name) }.to_set
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: ^zeResult$
+
   - ## Rest
     :set_id: hSignalEvent_rest_entry
     :domain: hSignalEvent_entry - (hSignalEvent_hKernel_with_group_entry + hSignalEvent_hKernel_without_group_entry + hSignalEvent_eventMemory_entry)


### PR DESCRIPTION
- Add metadata for traffic 
- Add error checking for traffic (not sending traffic message if error)
    - For profiled commands, use event errors 
    - For non-profiled commands (zeMakeResidant and co), created a `_exit` callback