### PR TITLE
Fix non imm

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -437,8 +437,8 @@ def enable_events_ze(channel_name, tracing_mode: 'default', profiling: true)
     exec("#{lttng_enable} lttng_ust_zex:*")
     exec("#{lttng_enable} lttng_ust_ze_properties:*")
     ze_disable_events = ['lttng_ust_ze:zeKernelSetArgumentValue*', 'lttng_ust_ze:ze*Get*Properties*',
-                         'lttng_ust_ze:zeKernelGetName']
-    ze_disable_query = ['lttng_ust_ze:*QueryStatus', 'lttng_ust_ze:*ProcAddrTable*']
+                         'lttng_ust_ze:zeKernelGetName*']
+    ze_disable_query = ['lttng_ust_ze:*QueryStatus*', 'lttng_ust_ze:*ProcAddrTable*']
     ze_disable_loader = ['lttng_ust_ze:*Loader*']
     ze_disable = ze_disable_events + ze_disable_query + ze_disable_loader
     exec("#{lttng_enable} lttng_ust_ze:* -x #{ze_disable.join(',')}")

--- a/ze/btx_zeinterval_callbacks.cpp
+++ b/ze/btx_zeinterval_callbacks.cpp
@@ -657,22 +657,23 @@ static void event_profiling_callback(void *btx_handle, void *usr_data, int64_t t
 }
 
 static void zeCommandListReset_entry_callback(void *btx_handle, void *usr_data, int64_t ts,
-                                     const char *hostname, int64_t vpid, uint64_t vtid, ze_command_list_handle_t hCommandList)
-{
+                                              const char *hostname, int64_t vpid, uint64_t vtid,
+                                              ze_command_list_handle_t hCommandList) {
   auto *data = static_cast<data_t *>(usr_data);
   data->entry_state.set_data({hostname, vpid, vtid}, hCommandList);
 }
 
 static void zeCommandListReset_exit_callback(void *btx_handle, void *usr_data, int64_t ts,
-                                     const char *hostname, int64_t vpid, uint64_t vtid, ze_result_t zeResult) {
+                                             const char *hostname, int64_t vpid, uint64_t vtid,
+                                             ze_result_t zeResult) {
 
   auto *data = static_cast<data_t *>(usr_data);
   if (zeResult == ZE_RESULT_SUCCESS) {
-    auto hCommandList = data->entry_state.get_data<ze_command_list_handle_t>({hostname, vpid, vtid});
+    auto hCommandList =
+        data->entry_state.get_data<ze_command_list_handle_t>({hostname, vpid, vtid});
     data->commandListToEvents[{hostname, vpid, hCommandList}].clear();
   }
 }
-
 
 static void event_profiling_result_callback(void *btx_handle, void *usr_data, int64_t ts,
                                             const char *hostname, int64_t vpid, uint64_t vtid,
@@ -758,9 +759,7 @@ static void zeEventDestroy_exit_callback(void *btx_handle, void *usr_data, int64
     return;
 
   data->eventToBtxDesct.erase({hostname, vpid, hEvent});
-
 }
-
 
 /*
  * Sampling
@@ -942,10 +941,9 @@ void btx_register_usr_callbacks(void *btx_handle) {
                                                           &zeEventDestroy_exit_callback);
 
   btx_register_callbacks_lttng_ust_ze_zeCommandListReset_entry(btx_handle,
-                                                           &zeCommandListReset_entry_callback);
+                                                               &zeCommandListReset_entry_callback);
   btx_register_callbacks_lttng_ust_ze_zeCommandListReset_exit(btx_handle,
-                                                          &zeCommandListReset_exit_callback);
-
+                                                              &zeCommandListReset_exit_callback);
 
   /* Sampling */
   btx_register_callbacks_lttng_ust_ze_sampling_gpu_energy(

--- a/ze/btx_zeinterval_callbacks.cpp
+++ b/ze/btx_zeinterval_callbacks.cpp
@@ -656,6 +656,24 @@ static void event_profiling_callback(void *btx_handle, void *usr_data, int64_t t
     data->commandListToEvents[{hostname, vpid, hCommandList}].insert(hEvent);
 }
 
+static void zeCommandListReset_entry_callback(void *btx_handle, void *usr_data, int64_t ts,
+                                     const char *hostname, int64_t vpid, uint64_t vtid, ze_command_list_handle_t hCommandList)
+{
+  auto *data = static_cast<data_t *>(usr_data);
+  data->entry_state.set_data({hostname, vpid, vtid}, hCommandList);
+}
+
+static void zeCommandListReset_exit_callback(void *btx_handle, void *usr_data, int64_t ts,
+                                     const char *hostname, int64_t vpid, uint64_t vtid, ze_result_t zeResult) {
+
+  auto *data = static_cast<data_t *>(usr_data);
+  if (zeResult == ZE_RESULT_SUCCESS) {
+    auto hCommandList = data->entry_state.get_data<ze_command_list_handle_t>({hostname, vpid, vtid});
+    data->commandListToEvents[{hostname, vpid, hCommandList}].clear();
+  }
+}
+
+
 static void event_profiling_result_callback(void *btx_handle, void *usr_data, int64_t ts,
                                             const char *hostname, int64_t vpid, uint64_t vtid,
                                             ze_event_handle_t hEvent, ze_result_t status,
@@ -676,7 +694,6 @@ static void event_profiling_result_callback(void *btx_handle, void *usr_data, in
   // We don't erase, may have one entry for multiple result
   const auto &[vtid_submission, commandQueueDesc, hCommandList, hCommandListIsImmediate, device,
                commandName, lltngMin, clockLttngDevice, type, ptr] = it_p->second;
-
   std::string metadata = "";
   {
     std::stringstream ss_metadata;
@@ -741,7 +758,9 @@ static void zeEventDestroy_exit_callback(void *btx_handle, void *usr_data, int64
     return;
 
   data->eventToBtxDesct.erase({hostname, vpid, hEvent});
+
 }
+
 
 /*
  * Sampling
@@ -921,6 +940,12 @@ void btx_register_usr_callbacks(void *btx_handle) {
                                                            &zeEventDestroy_entry_callback);
   btx_register_callbacks_lttng_ust_ze_zeEventDestroy_exit(btx_handle,
                                                           &zeEventDestroy_exit_callback);
+
+  btx_register_callbacks_lttng_ust_ze_zeCommandListReset_entry(btx_handle,
+                                                           &zeCommandListReset_entry_callback);
+  btx_register_callbacks_lttng_ust_ze_zeCommandListReset_exit(btx_handle,
+                                                          &zeCommandListReset_exit_callback);
+
 
   /* Sampling */
   btx_register_callbacks_lttng_ust_ze_sampling_gpu_energy(


### PR DESCRIPTION
Need to clean up the associated events to the command list, when the command list is reset.
If not old event (who are trigger at the end) will have wrong born-min