### PR TITLE
Remove non events not used by interval

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -473,7 +473,10 @@ def enable_events_cl(channel_name, tracing_mode: 'default', profiling: true)
     exec("#{lttng_enable} lttng_ust_opencl_arguments:*")
     exec("#{lttng_enable} lttng_ust_opencl_build:infos*")
   when 'default'
-    exec("#{lttng_enable} lttng_ust_opencl_profiling:*") if profiling
+    if profiling
+      exec("#{lttng_enable} lttng_ust_opencl_profiling:*")
+      exec("#{lttng_enable} lttng_ust_opencl_arguments:kernel_info")
+    end
     # Wildcard using the * character are supported at the end of tracepoint names.
     #   https://lttng.org/man/1/lttng-enable-event/v2.8/#doc-_understanding_event_rule_conditions
     # Disable-event doesn't have wildcards

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -448,7 +448,6 @@ def enable_events_ze(channel_name, tracing_mode: 'default', profiling: true)
     #   https://lttng.org/man/1/lttng-enable-event/v2.8/#doc-_understanding_event_rule_conditions
     # Disable-event doesn't have wildcards
     # So we enable and disable on the same line
-    exec("#{lttng_enable} lttng_ust_ze_build:log*")
     exec("#{lttng_enable} lttng_ust_ze_profiling:*") if profiling
     exec("#{lttng_enable} lttng_ust_zex:*")
     exec("#{lttng_enable} lttng_ust_ze_properties:*")
@@ -475,9 +474,6 @@ def enable_events_cl(channel_name, tracing_mode: 'default', profiling: true)
     exec("#{lttng_enable} lttng_ust_opencl_build:infos*")
   when 'default'
     exec("#{lttng_enable} lttng_ust_opencl_profiling:*") if profiling
-    exec("#{lttng_enable} lttng_ust_opencl_devices:*")
-    exec("#{lttng_enable} lttng_ust_opencl_arguments:*")
-    exec("#{lttng_enable} lttng_ust_opencl_build:infos*")
     # Wildcard using the * character are supported at the end of tracepoint names.
     #   https://lttng.org/man/1/lttng-enable-event/v2.8/#doc-_understanding_event_rule_conditions
     # Disable-event doesn't have wildcards


### PR DESCRIPTION
In the default mode, remove the events not used by interval.

- If not, they are passed around and finish to be written to disk with the `aggregated` events.
 - Then, during the replay, with it a `file` limits. 
 
 Of course, this is not a fix for the `file` limits but just a "cleaning" so that by default we just generate events that we use for the tally / interval.
 
 At term, we should allow user to specify events to enable/disable, and find a real solution for the file limits (smarted use of `--source` or  tree reduction) 