### PR TITLE
Remove useless message in interval and aggreg

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ PKG_CHECK_MODULES([PROTOBUF], [protobuf >= 3.0])
 AX_RUBY_EXTENSION([cast-to-yaml], [yes])
 AX_RUBY_EXTENSION([nokogiri], [yes])
 AX_RUBY_EXTENSION([babeltrace2], [yes])
-AX_RUBY_EXTENSION([metababel >= 1.1.1], [yes])
+AX_RUBY_EXTENSION([metababel >= 1.2.0], [yes])
 
 # Checks for header files.
 AC_CHECK_HEADERS([inttypes.h stddef.h stdint.h stdlib.h string.h unistd.h])

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -76,7 +76,7 @@ module BTComponentClassRefinement
     attr_accessor :plugins_path, :cli_v
 
     def bt2_escape(str)
-      str.gsub(/([*?\[.:\\])/,'\\\\\1')
+      str.gsub(/([*?\[.:\\])/, '\\\\\1')
     end
 
     def add(component_class, name, params: {},
@@ -187,11 +187,12 @@ def get_components(names)
   end
 end
 
-def get_and_add_components(graph, _command, names)
+def get_and_add_components(graph, command, names)
   get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
     raise "#{name} plugins was not found" unless comp
+
     case name
     when 'sink.text.rubypretty'
       graph.add_simple_sink('rubypretty', comp)
@@ -236,6 +237,18 @@ def get_and_add_components(graph, _command, names)
                 params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
       graph.add(comp, name) if need_muxer(ARGV.first)
+    when 'filter.btx_stripper.stripper'
+      filter_prefix = case command
+                      when 'to_interval'
+                        'lttng:'
+                      when 'to_aggreg'
+                        'aggreg:'
+                      else
+                        raise("#{command} for 'filter.btx_stripper.stripper' not supported")
+                      end
+      graph.add(comp, 'filter_btx_stripper_stripper',
+                params: { 'filter_prefix' => filter_prefix })
+
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
       graph.add(comp, name.gsub('.', '_'))
@@ -299,8 +312,8 @@ class BabeltraceParserThapi < OptionParserWithDefaultAndValidation
     super
     on('-h', '--help', 'Prints this help') { print_help_and_exit(self, exit_code: 0) }
     on('-b', '--backends BACKENDS', Array, "Select which and how backends' need to handled.",
-            'Format: backend_name[:backend_level],...',
-            default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
+       'Format: backend_name[:backend_level],...',
+       default: ['omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1'])
     on('--debug', default: false)
     on('--[no-]muxer')
     on('-v', '--version', 'Print the version string') do

--- a/xprof/Makefile.am
+++ b/xprof/Makefile.am
@@ -71,11 +71,14 @@ $(BTX_TALLY_GENERATED) &: $(srcdir)/btx_aggreg_model.yaml $(srcdir)/btx_tally_pa
 $(BTX_AGGREG_GENERATED) &: $(srcdir)/btx_interval_model.yaml $(srcdir)/btx_aggreg_model.yaml $(srcdir)/btx_aggreg_params.yaml
 	$(METABABEL) -u $(srcdir)/btx_interval_model.yaml -d $(srcdir)/btx_aggreg_model.yaml -t FILTER -o btx_filter_aggreg -p btx_aggreg -c aggreg --params $(srcdir)/btx_aggreg_params.yaml
 
-$(BTX_STRIPPER_GENERATED) &:
-	$(METABABEL) -t FILTER -o btx_filter_stripper -p btx_stripper -c stripper --enable-callbacks on_downstream
+$(BTX_STRIPPER_GENERATED) &: btx_stripper_param.yaml
+	$(METABABEL) -t FILTER -o btx_filter_stripper -p btx_stripper -c stripper --enable-callbacks on_downstream --params btx_stripper_param.yaml
 
 btx_stripper_callbacks.cpp:
-	$(METABABEL) --display-shared-callback stripper > $@
+	$(METABABEL) --display-shared-callback stripper.cpp > $@
+
+btx_stripper_param.yaml:
+	$(METABABEL) --display-shared-callback stripper_params.yaml > $@
 
 BUILT_SOURCES = \
 	$(BTX_TALLY_GENERATED) \
@@ -239,6 +242,7 @@ CLEANFILES = \
 	perfetto_prunned.pb.h \
 	perfetto_prunned.pb.cc \
 	btx_stripper_callbacks.cpp \
+	btx_stripper_param.yaml \
 	$(BTX_TIMELINE_GENERATED) \
 	$(BTX_TALLY_GENERATED) \
 	$(BTX_AGGREG_GENERATED) \


### PR DESCRIPTION
To remove the useless message we have two options:

- Either use the `--drop` in metababel at the creation of the component. This work well for Aggreg, but hard for Interval
- Modify the striper to be also a `filter`. This is was is done in the PR (relly on https://github.com/TApplencourt/metababel/pull/146) 


One current limitation is that the `stripper` can take only one`prefix` and not a list of prefix / regex. That may be a problem, as for example we may want to send  around the names of the devices (who are not part of the aggregate data class but maybe required for tally)

It's trivial to implement a `regex matching` on the stripper if required (a performance impact may be see for people doing the timeline, none for tally people)

It seems cleaner for me to have a `stripper / filter` to modify the behavior of intermediate components, as it's more general than particular components dropping unknown messages.  But the "drop message" is arguably a more straightforward. It only works for aggregates, but it is simple. And at the end `aggregate` is really what matter.

So 🤷🏽 

I will let you decide, it was not too painful to implement as a concept, so can revert back.