### PR TITLE
Handle empty hostname in trace

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -287,13 +287,18 @@ def create_and_run_graph(command, inputs)
       $stdout.flush
       File.write(name, cli)
     end
-
     graph.run
-    modify_metadata(command, inputs.first)
   end
 
-  no_gc(command, inputs)
-  GC.start
+  begin
+    no_gc(command, inputs)
+  rescue ArgumentError
+    # No source, no output folder, no metadata
+  else
+    modify_metadata(command, inputs.first)
+  ensure
+    GC.start
+  end
 end
 
 #    _                       _    ___

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -590,7 +590,6 @@ def on_node_processing(backends, syncd)
          else
            'aggreg'
          end
-
   if type && OPTIONS[:analysis]
     opts = ["to_#{type}"]
     opts << "--output #{thapi_trace_dir_tmp}"
@@ -610,7 +609,8 @@ def on_node_processing(backends, syncd)
 
   thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
 
-  FileUtils.cp(File.join(thapi_trace_dir_tmp, 'thapi_metadata.yaml'),
+  # Because of `traced-rank`, `mpi_master` may not have any trace avalaible.
+  FileUtils.cp(Dir.glob("#{thapi_trace_dir_tmp_root}/*/thapi_metadata.yaml").first,
                File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml'))
 
   exec("mv -T #{thapi_trace_dir_tmp_root} #{thapi_trace_dir_root}") unless OPTIONS[:'trace-output']


### PR DESCRIPTION
When `traced-ranks` is used, some hostname may have no trace. It was tripping `babeltrace_thapi`.

Change:
- `babeltrace_thapi` just warn if the trace is empty (will still raise if no metadata)
- `xprof` doesn't assume that the `master` node has a metadata.yaml; just find the first one available.

Thanks @khossain4337 for the bug report. 