### PR TITLE
Discard medatata

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -274,21 +274,23 @@ def modify_metadata(command, trace)
 end
 
 def bt_graphs
-  source_comp = if $options[:live]
-                  'source.ctf.lttng_live'
-                else
-                  'source.ctf.fs'
-                end
+  @bt_graphs ||= begin
+    source_comp = if $options[:live]
+                    'source.ctf.lttng_live'
+                  else
+                    'source.ctf.fs'
+                  end
 
-  { 'tally' => ['filter.utils.muxer', 'filter.intervals.interval',
-                'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
-    'timeline' => ['filter.utils.muxer', 'filter.intervals.interval',
-                   'sink.btx_timeline.timeline'],
-    'trace' => ['filter.utils.muxer', 'sink.text.rubypretty'],
-    'to_interval' => ['filter.utils.muxer', 'filter.intervals.interval',
-                      'filter.btx_stripper.stripper', 'sink.ctf.fs'],
-    'to_aggreg' => ['filter.utils.muxer', 'filter.intervals.interval', 'filter.btx_aggreg.aggreg',
-                    'filter.btx_stripper.stripper', 'sink.ctf.fs'] }.transform_values { |l| [source_comp] + l }
+    { 'tally' => ['filter.utils.muxer', 'filter.intervals.interval',
+                  'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
+      'timeline' => ['filter.utils.muxer', 'filter.intervals.interval',
+                     'sink.btx_timeline.timeline'],
+      'trace' => ['filter.utils.muxer', 'sink.text.rubypretty'],
+      'to_interval' => ['filter.utils.muxer', 'filter.intervals.interval',
+                        'filter.btx_stripper.stripper', 'sink.ctf.fs'],
+      'to_aggreg' => ['filter.utils.muxer', 'filter.intervals.interval', 'filter.btx_aggreg.aggreg',
+                      'filter.btx_stripper.stripper', 'sink.ctf.fs'] }.transform_values { |l| [source_comp] + l }
+  end
 end
 
 def create_and_run_graph(command, graph_str, inputs)

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -235,8 +235,14 @@ def get_and_add_components(graph, names, l_inputs)
     when 'sink.btx_timeline.timeline'
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'] })
+    when 'sink.btx_timeline.timeline'
+      graph.add(comp, 'timeline',
+                params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
       graph.add(comp, name) if need_muxer(ARGV.first)
+    when 'filter.btx_aggreg.aggreg'
+      graph.add(comp, 'aggreg',
+                params: { 'discard_metadata' => $options[:'discard-metadata'] })
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
       graph.add(comp, name.gsub('.', '_'))
@@ -399,6 +405,7 @@ subcommands = {
   'to_aggreg' =>
     BabeltraceParserThapi.new do |parser|
       parser.banner = 'Usage: babeltrace_thapi to_aggreg [OPTIONS] trace_directory...'
+      parser.on('--[no-]discard-metadata', default: true)
       parser.on('--output OUTPUT')
     end,
   'tally' =>
@@ -410,6 +417,7 @@ subcommands = {
       parser.on('--display-metadata', default: false)
       parser.on('--display-name-max-size SIZE', Integer, default: 80)
       parser.on('--display-kernel-verbose', default: false)
+      parser.on('--[no-]discard-metadata', default: false)
     end,
   'timeline' =>
     BabeltraceParserThapi.new do |parser|
@@ -417,7 +425,6 @@ subcommands = {
       parser.on('--output-path PATH', String, default: 'out.pftrace')
     end,
 }
-
 print_help_and_exit if ARGV.empty? || ARGV[0] == '--help'
 ARGV.insert(0, 'trace') unless subcommands.include?(ARGV.first)
 command = ARGV.shift

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -187,7 +187,7 @@ def get_components(names)
   end
 end
 
-def get_and_add_components(graph, _command, names, l_inputs)
+def get_and_add_components(graph, names, l_inputs)
   get_components(names).filter_map do |nc|
     name = nc.name
     comp = nc.comp
@@ -273,10 +273,30 @@ def modify_metadata(command, trace)
   File.write(File.join($options[:output], THAPI_METADATA_FILE), y.to_yaml)
 end
 
+def bt_graphs
+  h = { 'tally' => ['filter.utils.muxer', 'filter.intervals.interval',
+                    'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
+        'timeline' => ['filter.utils.muxer', 'filter.intervals.interval',
+                       'sink.btx_timeline.timeline'],
+        'trace' => ['filter.utils.muxer', 'sink.text.rubypretty'],
+        'to_interval' => ['filter.utils.muxer', 'filter.intervals.interval',
+                          'filter.btx_stripper.stripper', 'sink.ctf.fs'],
+        'to_aggreg' => ['filter.utils.muxer', 'filter.intervals.interval',
+                        'filter.btx_aggreg.aggreg', 'filter.btx_stripper.stripper', 'sink.ctf.fs'] }
+  # Add Source
+  source_comp = if $options[:live]
+                  'source.ctf.lttng_live'
+                else
+                  'source.ctf.fs'
+                end
+  h.transform_values { |l| [source_comp] + l }
+end
+
 def create_and_run_graph(command, inputs)
   def no_gc(command, inputs)
     graph = BT2::BTGraph.new
-    comp = get_and_add_components(graph, command, $thapi_graph[command], inputs)
+    thapi_graph = bt_graphs[command]
+    comp = get_and_add_components(graph, thapi_graph, inputs)
     connects(graph, comp)
 
     if $options[:debug]
@@ -425,15 +445,4 @@ $options[:'backend-names'] = $options[:backends].map { |name_level| name_level.s
 # Setup Logger
 LOGGER = Logger.new($stdout)
 
-$thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
-                             'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
-                 'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
-                                'sink.btx_timeline.timeline'],
-                 'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
-                 'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
-                                   'filter.btx_stripper.stripper', 'sink.ctf.fs'],
-                 'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
-                                 'filter.btx_aggreg.aggreg', 'filter.btx_stripper.stripper', 'sink.ctf.fs'] }
-
-$thapi_graph[command][0] = 'source.ctf.lttng_live' if $options[:live]
 create_and_run_graph(command, ARGV)

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -430,11 +430,10 @@ $thapi_graph = { 'tally' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.inte
                  'timeline' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                 'sink.btx_timeline.timeline'],
                  'trace' => ['source.ctf.fs', 'filter.utils.muxer', 'sink.text.rubypretty'],
-                 'trace_live' => ['source.ctf.lttng_live', 'filter.utils.muxer', 'sink.text.rubypretty'],
                  'to_interval' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                    'filter.btx_stripper.stripper', 'sink.ctf.fs'],
                  'to_aggreg' => ['source.ctf.fs', 'filter.utils.muxer', 'filter.intervals.interval',
                                  'filter.btx_aggreg.aggreg', 'filter.btx_stripper.stripper', 'sink.ctf.fs'] }
 
-command = 'trace_live' if command == 'trace' && $options[:live]
+$thapi_graph[command][0] = 'source.ctf.lttng_live' if $options[:live]
 create_and_run_graph(command, ARGV)

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -274,29 +274,27 @@ def modify_metadata(command, trace)
 end
 
 def bt_graphs
-  h = { 'tally' => ['filter.utils.muxer', 'filter.intervals.interval',
-                    'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
-        'timeline' => ['filter.utils.muxer', 'filter.intervals.interval',
-                       'sink.btx_timeline.timeline'],
-        'trace' => ['filter.utils.muxer', 'sink.text.rubypretty'],
-        'to_interval' => ['filter.utils.muxer', 'filter.intervals.interval',
-                          'filter.btx_stripper.stripper', 'sink.ctf.fs'],
-        'to_aggreg' => ['filter.utils.muxer', 'filter.intervals.interval',
-                        'filter.btx_aggreg.aggreg', 'filter.btx_stripper.stripper', 'sink.ctf.fs'] }
-  # Add Source
   source_comp = if $options[:live]
                   'source.ctf.lttng_live'
                 else
                   'source.ctf.fs'
                 end
-  h.transform_values { |l| [source_comp] + l }
+
+  { 'tally' => ['filter.utils.muxer', 'filter.intervals.interval',
+                'filter.btx_aggreg.aggreg', 'sink.btx_tally.tally'],
+    'timeline' => ['filter.utils.muxer', 'filter.intervals.interval',
+                   'sink.btx_timeline.timeline'],
+    'trace' => ['filter.utils.muxer', 'sink.text.rubypretty'],
+    'to_interval' => ['filter.utils.muxer', 'filter.intervals.interval',
+                      'filter.btx_stripper.stripper', 'sink.ctf.fs'],
+    'to_aggreg' => ['filter.utils.muxer', 'filter.intervals.interval', 'filter.btx_aggreg.aggreg',
+                    'filter.btx_stripper.stripper', 'sink.ctf.fs'] }.transform_values { |l| [source_comp] + l }
 end
 
-def create_and_run_graph(command, inputs)
-  def no_gc(command, inputs)
+def create_and_run_graph(command, graph_str, inputs)
+  def no_gc(command, graph_str, inputs)
     graph = BT2::BTGraph.new
-    thapi_graph = bt_graphs[command]
-    comp = get_and_add_components(graph, thapi_graph, inputs)
+    comp = get_and_add_components(graph, graph_str, inputs)
     connects(graph, comp)
 
     if $options[:debug]
@@ -311,7 +309,7 @@ def create_and_run_graph(command, inputs)
   end
 
   begin
-    no_gc(command, inputs)
+    no_gc(command, graph_str, inputs)
   rescue ArgumentError
     # No source, no output folder, no metadata
   else
@@ -444,5 +442,4 @@ $options[:'backend-names'] = $options[:backends].map { |name_level| name_level.s
 #
 # Setup Logger
 LOGGER = Logger.new($stdout)
-
-create_and_run_graph(command, ARGV)
+create_and_run_graph(command, bt_graphs[command], ARGV)

--- a/xprof/btx_aggreg.cpp
+++ b/xprof/btx_aggreg.cpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <metababel/metababel.h>
 #include <unordered_map>
+#include <iostream>
 
 using name_t = std::string;
 using metadata_t = std::string;
@@ -16,10 +17,16 @@ struct aggreg_s {
   std::unordered_map<_hptbn_t, TallyCoreBase> host;
   std::unordered_map<_hptbnm_t, TallyCoreBase> traffic;
   std::unordered_map<_hptn_dsb_nm_t, TallyCoreBase> device;
+  bool discard_metadata;
 };
 using aggreg_t = struct aggreg_s;
 
 static void initialize_component_callback(void **usr_data) { *usr_data = new aggreg_t; }
+
+static void read_params_callback(void *usr_data, btx_params_t *usr_params) {
+  auto *data = static_cast<aggreg_t *>(usr_data);
+  data->discard_metadata = !!usr_params->discard_metadata;
+}
 
 static void finalize_component_callback(void *usr_data) {
   auto *data = static_cast<aggreg_t *>(usr_data);
@@ -62,7 +69,11 @@ static void traffic_usr_callback(void *btx_handle, void *usr_data, const char *h
                                  const char *name, uint64_t size, const char *metadata) {
 
   auto *data = static_cast<aggreg_t *>(usr_data);
-  data->traffic[{hostname, vpid, vtid, (backend_t)backend_id, name, metadata}] += {size, false};
+  if (data->discard_metadata)
+    data->traffic[{hostname, vpid, vtid, (backend_t)backend_id, name, "discarded_metadata"}] +=
+        {size, false};
+  else
+    data->traffic[{hostname, vpid, vtid, (backend_t)backend_id, name, metadata}] += {size, false};
 }
 
 static void device_usr_callback(void *btx_handle, void *usr_data, const char *hostname,
@@ -71,7 +82,10 @@ static void device_usr_callback(void *btx_handle, void *usr_data, const char *ho
                                 bt_bool err, const char *metadata) {
 
   auto *data = static_cast<aggreg_t *>(usr_data);
-  data->device[{hostname, vpid, vtid, did, sdid, name, metadata}] += {dur, (bool)err};
+  if (data->discard_metadata)
+    data->device[{hostname, vpid, vtid, did, sdid, name, "discarded_metadata"}] += {dur, (bool)err};
+  else
+    data->device[{hostname, vpid, vtid, did, sdid, name, metadata}] += {dur, (bool)err};
 }
 
 // Merge all the aggreg messages in the same trace
@@ -104,6 +118,8 @@ static void aggreg_traffic_callback(void *btx_handle, void *usr_data, const char
 
 void btx_register_usr_callbacks(void *btx_handle) {
   btx_register_callbacks_initialize_component(btx_handle, &initialize_component_callback);
+  btx_register_callbacks_read_params(btx_handle, &read_params_callback);
+
   btx_register_callbacks_finalize_processing(btx_handle, &finalize_processing_callback);
   btx_register_callbacks_finalize_component(btx_handle, &finalize_component_callback);
 

--- a/xprof/btx_aggreg_params.yaml
+++ b/xprof/btx_aggreg_params.yaml
@@ -1,14 +1,4 @@
 :type: map
 :entries:
-  - :name: display
-    :type: string
-  - :name: name
-    :type: string
-  - :name: display_mode
-    :type: string
-  - :name: display_metadata
-    :type: bool
-  - :name: display_name_max_size
-    :type: integer_unsigned
-  - :name: display_kernel_verbose
+  - :name: discard_metadata
     :type: bool

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -594,6 +594,8 @@ def on_node_processing(backends, syncd)
     opts = ["to_#{type}"]
     opts << "--output #{thapi_trace_dir_tmp}"
     opts << "--backends #{backends.join(',')}"
+    opts << '--no-discard-metadata' if  type == 'aggreg' && OPTIONS.include?(:'kernel-verbose')
+
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
     FileUtils.rm_f(lttng_trace_dir_tmp)
   else
@@ -708,6 +710,7 @@ if __FILE__ == $PROGRAM_NAME
             'Default path is something like: $THAPI_HOME/thapi-traces/thapi--%Y-%m-%d--%Hh%Mm%Ss',
             '$THAPI_HOME defaults to $HOME') do |p|
     raise(OptionParser::ParseError, "#{p} already exists") if mpi_master? && File.exist?(p)
+
     p
   end
 


### PR DESCRIPTION
@colleeneb  have a MPI job (512) where the final reply of aggregations take for ever. I suspect if due to too much metadata 
(she have million of different size of the MPI traffic)

By default let not trace the medatada, but keep them when using `k`
```
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D) |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H) |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M) |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D) |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H) |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M) |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -k -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M)[discarded_metadata] |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D)[discarded_metadata] |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H)[discarded_metadata] |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M)[discarded_metadata] |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S)[discarded_metadata] |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D)[discarded_metadata] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[discarded_metadata] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[discarded_metadata] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[discarded_metadata] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[discarded_metadata] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[discarded_metadata] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[discarded_metadata] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -k ./a.out  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
        zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
        zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
        zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
        zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
        zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
        zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
zeCommandListAppendMemoryCopy(M2D) |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
zeCommandListAppendMemoryCopy(D2H) |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
zeCommandListAppendMemoryCopy(M2M) |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r -k  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
        zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
        zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
        zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
        zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
        zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
        zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
```