### PR TITLE
Discard Metadata

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -235,8 +235,14 @@ def get_and_add_components(graph, names, l_inputs)
     when 'sink.btx_timeline.timeline'
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'] })
+    when 'sink.btx_timeline.timeline'
+      graph.add(comp, 'timeline',
+                params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
       graph.add(comp, name) if need_muxer(ARGV.first)
+    when 'filter.btx_aggreg.aggreg'
+      graph.add(comp, 'aggreg',
+                params: { 'discard_metadata' => $options[:'discard-metadata'] })
     else
       # `.` is not allowed in the babeltrace components name when using the CLI
       graph.add(comp, name.gsub('.', '_'))
@@ -399,6 +405,7 @@ subcommands = {
   'to_aggreg' =>
     BabeltraceParserThapi.new do |parser|
       parser.banner = 'Usage: babeltrace_thapi to_aggreg [OPTIONS] trace_directory...'
+      parser.on('--[no-]discard-metadata', default: true)
       parser.on('--output OUTPUT')
     end,
   'tally' =>
@@ -410,6 +417,7 @@ subcommands = {
       parser.on('--display-metadata', default: false)
       parser.on('--display-name-max-size SIZE', Integer, default: 80)
       parser.on('--display-kernel-verbose', default: false)
+      parser.on('--[no-]discard-metadata', default: false)
     end,
   'timeline' =>
     BabeltraceParserThapi.new do |parser|
@@ -417,7 +425,6 @@ subcommands = {
       parser.on('--output-path PATH', String, default: 'out.pftrace')
     end,
 }
-
 print_help_and_exit if ARGV.empty? || ARGV[0] == '--help'
 ARGV.insert(0, 'trace') unless subcommands.include?(ARGV.first)
 command = ARGV.shift

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -235,9 +235,6 @@ def get_and_add_components(graph, names, l_inputs)
     when 'sink.btx_timeline.timeline'
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'] })
-    when 'sink.btx_timeline.timeline'
-      graph.add(comp, 'timeline',
-                params: { 'output_path' => $options[:'output-path'] })
     when 'filter.utils.muxer'
       graph.add(comp, name) if need_muxer(ARGV.first)
     when 'filter.btx_aggreg.aggreg'

--- a/xprof/btx_aggreg_params.yaml
+++ b/xprof/btx_aggreg_params.yaml
@@ -1,14 +1,4 @@
 :type: map
 :entries:
-  - :name: display
-    :type: string
-  - :name: name
-    :type: string
-  - :name: display_mode
-    :type: string
-  - :name: display_metadata
-    :type: bool
-  - :name: display_name_max_size
-    :type: integer_unsigned
-  - :name: display_kernel_verbose
+  - :name: discard_metadata
     :type: bool

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -583,6 +583,7 @@ def on_node_processing_babeltrace(backends)
   opts = ["to_#{type}"]
   opts << "--output #{thapi_trace_dir_tmp}"
   opts << "--backends #{backends.join(',')}"
+  opts << '--no-discard-metadata' if type == 'aggreg' && OPTIONS.include?(:'kernel-verbose')
   exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
 end
 


### PR DESCRIPTION
@colleeneb have a MPI job (512) where the final reply of aggregations take for ever. I suspect if due to too much metadata
(she have million of different size of the MPI traffic)

By default let not trace the medatada, but keep them when using `-k`
```
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof ./a.out | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D) |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H) |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M) |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D) |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H) |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M) |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -k -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:22+00:00
      zeCommandListAppendMemoryCopy | 724.56us |   0.37% |    15 |  48.30us |  10.23us | 489.08us |     0 |
zeCommandListAppendMemoryCopy(S2M)[discarded_metadata] |  8.96us |  12.61% |     4 |   2.24us |  2.08us |  2.40us |
zeCommandListAppendMemoryCopy(M2D)[discarded_metadata] |  5.68us |   8.00% |     7 | 811.43ns |    80ns |  2.88us |
zeCommandListAppendMemoryCopy(D2H)[discarded_metadata] |  2.72us |   3.83% |     1 |   2.72us |  2.72us |  2.72us |
zeCommandListAppendMemoryCopy(M2M)[discarded_metadata] |  2.56us |   3.60% |     1 |   2.56us |  2.56us |  2.56us |
zeCommandListAppendMemoryCopy(M2S)[discarded_metadata] |   160ns |   0.23% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D)[discarded_metadata] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[discarded_metadata] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[discarded_metadata] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[discarded_metadata] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[discarded_metadata] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[discarded_metadata] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[discarded_metadata] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -k ./a.out  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
        zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
        zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
        zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
        zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
        zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
        zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
zeCommandListAppendMemoryCopy(S2M) |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
zeCommandListAppendMemoryCopy(M2D) |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
zeCommandListAppendMemoryCopy(D2H) |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
zeCommandListAppendMemoryCopy(M2M) |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
zeCommandListAppendMemoryCopy(M2S) |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
zeCommandListAppendMemoryCopy(H2D) |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D) | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M) |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S) |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M) |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D) |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
applenco@x4315c6s0b0n0:~/slow> /home/applenco/THAPI/build/ici/bin/iprof -r -k  | grep "zeCommandListAppendMemoryCopy"
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-07-17T17:17:43+00:00
      zeCommandListAppendMemoryCopy | 662.72us |   0.35% |    15 |  44.18us |   9.88us | 443.07us |     0 |
        zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |  8.64us |  12.04% |     4 |   2.16us |  2.08us |  2.24us |
        zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] |  5.52us |   7.69% |     7 | 788.57ns |    80ns |  2.72us |
        zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |  3.04us |   4.24% |     1 |   3.04us |  3.04us |  3.04us |
        zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |  2.80us |   3.90% |     1 |   2.80us |  2.80us |  2.80us |
        zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |   160ns |   0.22% |     1 | 160.00ns |   160ns |   160ns |
        zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |    80ns |   0.11% |     1 |  80.00ns |    80ns |    80ns |
zeCommandListAppendMemoryCopy(M2D)[{ordinal: 1, index: 0}] | 4.71kB |   0.14% |     7 |  673.14B |  4B | 4.10kB |
zeCommandListAppendMemoryCopy(S2M)[{ordinal: 1, index: 0}] |    96B |   0.00% |     4 |   24.00B |  8B |    40B |
zeCommandListAppendMemoryCopy(M2S)[{ordinal: 1, index: 0}] |    64B |   0.00% |     1 |   64.00B | 64B |    64B |
zeCommandListAppendMemoryCopy(M2M)[{ordinal: 1, index: 0}] |    56B |   0.00% |     1 |   56.00B | 56B |    56B |
zeCommandListAppendMemoryCopy(D2H)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |
zeCommandListAppendMemoryCopy(H2D)[{ordinal: 1, index: 0}] |     4B |   0.00% |     1 |    4.00B |  4B |     4B |

```