### PR TITLE
mpi default

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -527,7 +527,12 @@ end
 
 def enable_events_mpi(channel_name, tracing_mode: 'default', profiling: true)
   lttng_enable = "lttng enable-event --userspace --session=#{lttng_session_uuid} --channel=#{channel_name}"
-  exec("#{lttng_enable} lttng_ust_mpi:*")
+  case tracing_mode
+  when 'full'
+    exec("#{lttng_enable} lttng_ust_mpi:*")
+  when 'default'
+    exec("#{lttng_enable} lttng_ust_mpi:* -x lttng_ust_mpi:MPI_WTime*")
+  end
   exec("#{lttng_enable} lttng_ust_mpi_type:*")
 end
 


### PR DESCRIPTION
Colleen find that PHASTA / LibCEED just spam `MPI_WTime` billions of times per minute. 

We should indeed give user a better way of  blacklisting events.