### PR TITLE
Handle nil return code

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -15,18 +15,27 @@ DATADIR = DATAROOTDIR
 
 class XprofExitCode
   @@exit_code = 0
-  def self.update(exit_code, name)
+  def self.update(status, name)
     # Keep only the first error
-    if exit_code.nil?
-      LOGGER.error("#{name} returned with a nil exit code (most probably due to a segault")
-      exit_code = 137
-    end
-
+    exit_code = if status.exitstatus.nil?
+                  LOGGER.error("#{name} : #{status}")
+                  139
+                else
+                  status.exitstatus
+                end
     @@exit_code = exit_code if @@exit_code == 0
   end
 
   def self.get
     @@exit_code
+  end
+end
+
+class XprofExitStatus
+  attr_reader :exitstatus
+
+  def initialize(exitstatus)
+    @exitstatus = exitstatus
   end
 end
 
@@ -48,8 +57,9 @@ module LoggerRefinement
   refine(Logger) do
     def info_block(message, &block)
       info("#{message}: entry") if message
-      block.call
+      r = block.call
       info("#{message}: exit") if message
+      r
     end
   end
 end
@@ -439,18 +449,18 @@ def launch_usr_bin(env, cmd)
   end.to_h
 
   begin
-    PTY.spawn(bash_env, *cmd) do |stdout, _stdin, _pid|
+    PTY.spawn(bash_env, *cmd) do |stdout, _stdin, pid|
       # Reading stdout will trigger Errno::EIO
       stdout.each { |line| print line }
     rescue Errno::EIO
       # Get the PTY status
-      _, status = Process.wait2(_pid)
-      return status.exitstatus
+      _, status = Process.wait2(pid)
+      return status
     end
   rescue Interrupt
     LOGGER.warn { 'Application Received Interrupt Signal' }
     # SigINT is 2
-    2
+    XprofExitStatus.new(2)
   rescue Errno::ENOENT
     warn("#{__FILE__}: Can't find executable #{cmd.first}")
     raise Errno::ENOENT
@@ -635,7 +645,7 @@ end
 #  |   | (_) (_ (/_ _> _> | | | (_|
 #                                _|
 
-# Some naming convension
+# Some naming convention
 # lm == function executed only local_master
 # gm ==  function executed only global_master
 
@@ -660,7 +670,7 @@ def gm_rename_folder
   # Replace it with a better name, and update the root metadata.
 
   thapi_trace_dir_tmp_root = File.dirname(thapi_trace_dir_tmp)
-  # Because of `traced-rank`, `mpi_master` may not have any trace avalaible,
+  # Because of `traced-rank`, `mpi_master` may not have any trace available,
   # so find the first hostname who have a metadata
   FileUtils.cp(Dir.glob("#{thapi_trace_dir_tmp_root}/*/thapi_metadata.yaml").first,
                File.join(thapi_trace_dir_tmp_root, 'thapi_metadata.yaml'))
@@ -702,7 +712,7 @@ def trace_and_on_node_processing(usr_argv)
 
     # Launch User Command
     begin
-      XprofExitCode.update(launch_usr_bin(h, usr_argv), usr_argv.join(" "))
+      XprofExitCode.update(launch_usr_bin(h, usr_argv), usr_argv.join(' '))
     rescue Errno::ENOENT
       teardown_lttng(syncd)
       raise
@@ -752,14 +762,13 @@ def gm_processing(folder)
          else
            $stdout.dup
          end
-
-    IO.popen([cmdname, *args]) do |pipe|
-      fo.puts(pipe.readlines)
-    end
-
+    pipe = IO.popen([cmdname, *args])
+    pid = pipe.pid
+    fo.puts(pipe.readlines)
     fo.close
+    _, status = Process.wait2(pid)
+    status
   end
-  $?.exitstatus
 end
 
 #
@@ -883,7 +892,7 @@ if __FILE__ == $PROGRAM_NAME
 
   if mpi_master?
     warn("THAPI: Trace location: #{folder}")
-    XprofExitCode.update(gm_processing(folder), "babeltrace_thapi") if OPTIONS[:analysis]
+    XprofExitCode.update(gm_processing(folder), 'babeltrace_thapi') if OPTIONS[:analysis]
   end
 
   exit(XprofExitCode.get)

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -15,8 +15,13 @@ DATADIR = DATAROOTDIR
 
 class XprofExitCode
   @@exit_code = 0
-  def self.update(exit_code)
+  def self.update(exit_code, name)
     # Keep only the first error
+    if exit_code.nil?
+      LOGGER.error("#{name} returned with a nil exit code (most probably due to a segault")
+      exit_code = 137
+    end
+
     @@exit_code = exit_code if @@exit_code == 0
   end
 
@@ -438,9 +443,9 @@ def launch_usr_bin(env, cmd)
       # Reading stdout will trigger Errno::EIO
       stdout.each { |line| print line }
     rescue Errno::EIO
-      # Wait for the PTY to finish, to set $?
-      Process.wait(_pid)
-      return $?.exitstatus
+      # Get the PTY status
+      _, status = Process.wait2(_pid)
+      return status.exitstatus
     end
   rescue Interrupt
     LOGGER.warn { 'Application Received Interrupt Signal' }
@@ -697,7 +702,7 @@ def trace_and_on_node_processing(usr_argv)
 
     # Launch User Command
     begin
-      XprofExitCode.update(launch_usr_bin(h, usr_argv))
+      XprofExitCode.update(launch_usr_bin(h, usr_argv), usr_argv.join(" "))
     rescue Errno::ENOENT
       teardown_lttng(syncd)
       raise
@@ -834,7 +839,7 @@ if __FILE__ == $PROGRAM_NAME
   parser.on('-h', '--help', 'Display this message') { print_help_and_exit(parser, exit_code: 0) }
 
   parser.on('--debug [LEVEL]', OptionParser::DecimalInteger, 'Set the Level of debug',
-            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::FATAL) do |d|
+            "If LEVEL is omitted the debug level with be set to #{Logger::INFO}", default: Logger::ERROR) do |d|
               d || Logger::INFO
             end
 
@@ -878,7 +883,7 @@ if __FILE__ == $PROGRAM_NAME
 
   if mpi_master?
     warn("THAPI: Trace location: #{folder}")
-    XprofExitCode.update(gm_processing(folder)) if OPTIONS[:analysis]
+    XprofExitCode.update(gm_processing(folder), "babeltrace_thapi") if OPTIONS[:analysis]
   end
 
   exit(XprofExitCode.get)


### PR DESCRIPTION
Fix the 
```
/home/videau/opt/thapi/0.0.7/bin/iprof:884:in `exit': no implicit conversion from nil to integer (TypeError)

  exit(XprofExitCode.get)
       ^^^^^^^^^^^^^^^^^
	from /home/videau/opt/thapi/0.0.7/bin/iprof:884:in `<main>'
```

Now return:
```
applenco@x4307c2s4b0n0:~/THAPI/build> ./ici/bin/iprof ./a.out
E, [2024-10-11T22:13:11.385479 #181857] ERROR -- : ./a.out returned with a nil exit code (most probably due to a segault
THAPI: Trace location: /home/applenco/thapi-traces/thapi_aggreg--2024-10-11T22:13:12+00:00
[...]
```

The clean way should be that PTY print the segfault. But I don't know how to do it... It print std err nornaly, but not the segfault message :( 


```
#include <stdio.h>
int main ()
{
  printf ("%s", 'a');
}
```
Simple segfaulting binary if one want to reproduce. 