### PR TITLE
Fix ffi fixed sized integers.

### DIFF
--- a/utils/gen_library_base.rb
+++ b/utils/gen_library_base.rb
@@ -14,6 +14,8 @@ def to_ffi_name(name, default = true)
     return ':uint64'
   when 'size_t'
     return ':size_t'
+  when /^(u{0-1}int\d+)_t$/
+    return ":#{$1}"
   when '_Bool'
     return ':bool'
   end

--- a/utils/gen_library_base.rb
+++ b/utils/gen_library_base.rb
@@ -14,7 +14,7 @@ def to_ffi_name(name, default = true)
     return ':uint64'
   when 'size_t'
     return ':size_t'
-  when /^(u{0-1}int\d+)_t$/
+  when /^(u?int\d+)_t$/
     return ":#{$1}"
   when '_Bool'
     return ':bool'


### PR DESCRIPTION
After this patch, we should not have any :uintxx_t inside the generated ruby libraries, but :uintxx

Will need to fix babeltrace2 bindings as well