### PR TITLE
Add exported extension to zeDriverGetExtensionFunctionAddress.

### DIFF
--- a/ze/gen_ze.rb
+++ b/ze/gen_ze.rb
@@ -240,32 +240,41 @@ EOF
 }
 
 $ze_commands.each { |c|
-  normal_wrapper.call(c, :lttng_ust_ze, ze_struct_types)
   puts <<EOF unless c.name.match(/zeGet.*ProcAddrTable/) || c.name.match(/zeLoaderInit|zelLoaderDriverCheck|zelLoaderTracingLayerInit|zeLoaderGetTracingHandle/)
 #{c.decl_hidden_alias};
 
 EOF
 }
 $zet_commands.each { |c|
-  normal_wrapper.call(c, :lttng_ust_zet, zet_struct_types)
   puts <<EOF unless c.name.match(/zetGet.*ProcAddrTable/)
 #{c.decl_hidden_alias};
 
 EOF
 }
 $zes_commands.each { |c|
-  normal_wrapper.call(c, :lttng_ust_zes, zes_struct_types)
   puts <<EOF unless c.name.match(/zesGet.*ProcAddrTable/)
 #{c.decl_hidden_alias};
 
 EOF
 }
 $zel_commands.each { |c|
-  normal_wrapper.call(c, :lttng_ust_zel, zel_struct_types)
   puts <<EOF if c.name.match(/^zelTracer/) && !c.name.match(/RegisterCallback$/)
 #{c.decl_hidden_alias};
 
 EOF
+}
+
+$ze_commands.each { |c|
+  normal_wrapper.call(c, :lttng_ust_ze, ze_struct_types)
+}
+$zet_commands.each { |c|
+  normal_wrapper.call(c, :lttng_ust_zet, zet_struct_types)
+}
+$zes_commands.each { |c|
+  normal_wrapper.call(c, :lttng_ust_zes, zes_struct_types)
+}
+$zel_commands.each { |c|
+  normal_wrapper.call(c, :lttng_ust_zel, zel_struct_types)
 }
 
 $zex_commands.each { |c|

--- a/ze/ze_model.rb
+++ b/ze/ze_model.rb
@@ -421,6 +421,21 @@ def get_ffi_type(a)
   end
 end
 
+str = $ze_commands.select { |c| c.name.end_with?('Exp') }.map { |c|
+  <<EOF
+  if (strcmp(name, "#{c.name}") == 0) {
+    *ppFunctionAddress = (void *)(intptr_t)#{ZE_POINTER_NAMES[c]};
+    tracepoint(lttng_ust_ze, zeDriverGetExtensionFunctionAddress_exit, hDriver, name, ppFunctionAddress, ZE_RESULT_SUCCESS);
+    *ppFunctionAddress = (void *)(intptr_t)#{c.name}_hid;
+    return ZE_RESULT_SUCCESS;
+  }
+EOF
+}.join(<<EOF)
+  else
+EOF
+
+register_prologue "zeDriverGetExtensionFunctionAddress", str
+
 str = <<EOF
   if (_retval == ZE_RESULT_SUCCESS && *ppFunctionAddress) {
 EOF


### PR DESCRIPTION
Should allow tracing exported extensions queried through zeDriverGetExtensionFunctionAddress.