### PR TITLE
Add `update_ze_ddi_ver.rb` helper

### DIFF
--- a/ze/update_ze_ddi_ver.rb
+++ b/ze/update_ze_ddi_ver.rb
@@ -1,0 +1,105 @@
+require 'yaml'
+require 'erb'
+
+# ERB template for versioned DDI table structures
+# trim_mode '-' removes trailing newlines
+template = ERB.new <<~EOF, trim_mode: '-'
+  #ifndef _ZE_DDI_VER_H
+  #define _ZE_DDI_VER_H
+  #if defined(__cplusplus)
+  #pragma once
+  #endif
+  #include "ze_ddi.h"
+
+  #if defined(__cplusplus)
+  extern "C" {
+  #endif
+
+  <% dditables.values.each do |groups| -%>
+  ///////////////////////////////////////////////////////////////////////////////
+  /// <%= groups["versions"] %>
+  <% groups["strucs"].each do |dditable| -%>
+  typedef struct <%= dditable['name'] %>
+  {
+  <% dditable['members'].each do |member| -%>
+      <%= member["type"]["name"].ljust(59) %> <%= member["name"] %>;
+  <% end -%>
+  } <%= dditable["name"][1..] %>;
+
+  <% end -%>
+  <% end -%>
+
+  #if defined(__cplusplus)
+  } // extern "C"
+  #endif
+
+  #endif // _ZE_DDI_VER_H
+EOF
+
+
+# Parse existing DDI versioned structures from YAML file
+# Groups structures by their base name (stem) and tracks version numbers
+# Example:
+#   { "ze_device_dditable_t": # Stem
+#     versions: [1.2, 1.3]
+#     structs: [ze_device_dditable_t_1_2, ...]
+#   }
+#   ...
+
+dditables = YAML.load(`h2yaml ./include/ze_ddi_ver.h -Iinclude/`)['structs']
+# Add meta info used for the group by
+                .filter_map do |struct|
+  ms = /(.*_dditable_t)_(\d+)_(\d+)/.match(struct['name'])
+  next unless ms
+
+  struct['base_name'], *version = ms.captures
+  struct['version'] = version.join('.').to_f # "1_3" -> 1.3
+  struct
+end
+  # Groupy by base_name
+  .group_by { |dditable| dditable['base_name'] }.to_h
+  .transform_values do |dditables|
+     { 'versions' => dditables.map { |y| y['version'] },
+       'strucs' => dditables }
+end
+
+
+# Official current header
+ze_ddi_yaml = YAML.load(`h2yaml ./include/ze_ddi.h -Iinclude/`)
+
+# Extract the current API version from the official header DDI YAML file
+# Looks for the latest version in the _ze_api_version_t enum
+current_ze_version = ze_ddi_yaml['enums'].find do |enum|
+  enum['name'] == '_ze_api_version_t'
+end['members'].filter_map do |member|
+  match = /_(\d+)_(\d+)/.match(member['name'])
+  match && match.captures
+end.last
+
+
+# Find all the new members of `ze_.*_dditable` (not present in `ze_ddi_ver`),
+# put them in their own versioned structure in `dditables`
+ze_ddi_yaml['structs'].each do |struct|
+  
+  name = struct['name']
+  next unless  /_ze_.*_dditable_t/.match?(name)
+  # Initialize entry for completely new DDI table type
+  dditables[name] = { 'versions' => [], 'strucs' => [] } unless dditables.include?(name)
+
+  # Find members that are new (not present in any existing version)
+  new_members = struct['members'].reject do |member|
+    dditables[name]['strucs'].any? { |old_dditable| old_dditable['members'].include?(member) }
+  end
+  next if new_members.empty?
+
+  # Create new versioned structure for the new members
+  # Structure name format: #{base_name}_major_minor (e.g., ze_device_dditable_t_1_3)
+  struct['name'] = ([name] + current_ze_version).join('_')
+  struct['members'] = new_members
+  dditables[name]['strucs'].append(struct)
+  # Version format: major.minor as float (e.g., 1.3)
+  dditables[name]['versions'].append(current_ze_version.join(',').to_f)
+end
+
+# Generate header file
+puts template.result(binding)

--- a/ze/update_ze_ddi_ver.rb
+++ b/ze/update_ze_ddi_ver.rb
@@ -98,7 +98,7 @@ ze_ddi_yaml['structs'].each do |struct|
   struct['members'] = new_members
   dditables[name]['strucs'].append(struct)
   # Version format: major.minor as float (e.g., 1.3)
-  dditables[name]['versions'].append(current_ze_version.join(',').to_f)
+  dditables[name]['versions'].append(current_ze_version.join('.').to_f)
 end
 
 # Generate header file


### PR DESCRIPTION
A little script to generate `ze_ddi_ver.h`.
I take the official `ze_ddi.h`, an current `ze_ddi_ver.h` and output a updated `ze_ddi_ver.h`.

Note that: during the yaml conversion, the comment are lost (the @brief )
```
///////////////////////////////////////////////////////////////////////////////
/// [1.0, 1.3, 1.5]
/// @brief Table of CommandQueue functions pointers # This this is removed
typedef struct _ze_image_dditable_t_1_0
{
    ze_pfnImageGetProperties_t                                  pfnGetProperties;
    ze_pfnImageCreate_t                                         pfnCreate;
    ze_pfnImageDestroy_t                                        pfnDestroy;
} ze_image_dditable_t_1_0;

typedef struct _ze_image_dditable_t_1_3
{
    ze_pfnImageGetProperties_t                                  pfnGetProperties;
    ze_pfnImageCreate_t                                         pfnCreate;
    ze_pfnImageDestroy_t                                        pfnDestroy;
    ze_pfnImageGetAllocPropertiesExt_t                          pfnGetAllocPropertiesExt;
} ze_image_dditable_t_1_3;

typedef struct _ze_image_dditable_t_1_5
{
    ze_pfnImageGetProperties_t                                  pfnGetProperties;
    ze_pfnImageCreate_t                                         pfnCreate;
    ze_pfnImageDestroy_t                                        pfnDestroy;
    ze_pfnImageGetAllocPropertiesExt_t                          pfnGetAllocPropertiesExt;
    ze_pfnImageViewCreateExt_t                                  pfnViewCreateExt;
} ze_image_dditable_t_1_5;
```
Even if we want to keep the comment, the script is still useful. It make updating the ze_ddi_ver.h easy (just a vimdiff)
