### PR TITLE
Better make option

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -74,7 +74,7 @@ jobs:
       - run: ./autogen.sh
       - run: ../configure --prefix=`pwd`/ici
         working-directory: build
-      - run: make -j `nproc` install
+      - run: make install
         working-directory: build
       - name: Tar THAPI # https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss
         run: tar -cvf thapi.tar ./build/ici/


### PR DESCRIPTION

```
There are four levels of granularity when synchronizing output, specified by giving an argument to the option (e.g., ‘-Oline’ or ‘--output-sync=recurse’).

none

    This is the default: all output is sent directly as it is generated and no synchronization is performed.
line

    Output from each individual line of the recipe is grouped and printed as soon as that line is complete. If a recipe consists of multiple lines, they may be interspersed with lines from other recipes.
target

    Output from the entire recipe for each target is grouped and printed once the target is complete. This is the default if the --output-sync or -O option is given with no argument.


  --shuffle[={SEED|random|reverse|none}]
                              Perform shuffle of prerequisites and goals.
```