### PR TITLE
Introduce `thapi_sampling_daemon` 

### DIFF
--- a/integration_tests/sampling.bats
+++ b/integration_tests/sampling.bats
@@ -7,7 +7,7 @@ teardown_file() {
 }
 
 @test "sampling_heartbeat" {
-   LTTNG_UST_SAMPLING_ENERGY=0 LTTNG_UST_SAMPLING_HEARTBEAT=1 $THAPI_BIN_DIR/iprof --no-analysis --sample --trace-output heartbeat_trace -- bash -c 'sleep 2'
+   LTTNG_UST_ZE_SAMPLING_ENERGY=0 LTTNG_UST_SAMPLING_HEARTBEAT=1 $THAPI_BIN_DIR/iprof --no-analysis --sample --trace-output heartbeat_trace -- bash -c 'sleep 2'
    $THAPI_BIN_DIR/babeltrace_thapi  --no-restrict heartbeat_trace | grep heartbeat
    rm -rf heartbeat_trace
 }

--- a/sampling/Makefile.am
+++ b/sampling/Makefile.am
@@ -44,19 +44,16 @@ CLEANFILES = \
 BUILT_SOURCES = \
 	$(SAMPLING_STATIC_PROBES_INCL)
 
-#nodist_libThapiSampling_la_SOURCES = \
-#	$(SAMPLING_STATIC_PROBES_INCL)
+libThapiSampling_la_SOURCES = \
+	thapi_sampling.h \
+	thapi_sampling_register.h \
+	thapi_sampling.c
 
-#libThapiSampling_la_SOURCES = \
-#	thapi_sampling.h \
-#	thapi_sampling.c
+libThapiSampling_la_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include
+libThapiSampling_la_LDFLAGS = -lpthread -version-info 1:0:0 $(LTTNG_UST_LIBS)
 
-#libThapiSampling_la_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include $(LTTNG_UST_CFLAGS)
-#libThapiSampling_la_LDFLAGS = -lpthread -version-info 1:0:0 $(LTTNG_UST_LIBS)
-#libThapiSampling_la_LIBADD = libsamplingtracepoints.la
-
-#samplingdir = $(pkglibdir)/sampling
-#sampling_LTLIBRARIES = libThapiSampling.la
+samplingdir = $(pkglibdir)/sampling
+sampling_LTLIBRARIES = libThapiSampling.la
 
 bin_PROGRAMS = thapi_sampling_daemon
 
@@ -65,10 +62,11 @@ nodist_thapi_sampling_daemon_SOURCES = \
 
 thapi_sampling_daemon_SOURCES = \
 	thapi_sampling.h \
-	thapi_sampling.c
+	thapi_sampling_register.h \
+	thapi_sampling_daemon.c
 
 thapi_sampling_daemon_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include $(LTTNG_UST_CFLAGS)
 thapi_sampling_daemon_LDFLAGS = -lpthread
-thapi_sampling_daemon_LDADD = libsamplingtracepoints.la
+thapi_sampling_daemon_LDADD = libThapiSampling.la libsamplingtracepoints.la
 
 CLEANFILES += $(bin_PROGRAMS)

--- a/sampling/Makefile.am
+++ b/sampling/Makefile.am
@@ -32,7 +32,6 @@ libsamplingtracepoints_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils
 libsamplingtracepoints_la_CFLAGS = -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Wno-sign-compare $(WERROR) $(LTTNG_UST_CFLAGS)
 libsamplingtracepoints_la_LDFLAGS = $(LTTNG_UST_LIBS)
 
-
 EXTRA_DIST = \
 	sampling_events.yaml \
 	gen_sampling_custom_probes.rb
@@ -45,17 +44,31 @@ CLEANFILES = \
 BUILT_SOURCES = \
 	$(SAMPLING_STATIC_PROBES_INCL)
 
-nodist_libThapiSampling_la_SOURCES = \
+#nodist_libThapiSampling_la_SOURCES = \
+#	$(SAMPLING_STATIC_PROBES_INCL)
+
+#libThapiSampling_la_SOURCES = \
+#	thapi_sampling.h \
+#	thapi_sampling.c
+
+#libThapiSampling_la_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include $(LTTNG_UST_CFLAGS)
+#libThapiSampling_la_LDFLAGS = -lpthread -version-info 1:0:0 $(LTTNG_UST_LIBS)
+#libThapiSampling_la_LIBADD = libsamplingtracepoints.la
+
+#samplingdir = $(pkglibdir)/sampling
+#sampling_LTLIBRARIES = libThapiSampling.la
+
+bin_PROGRAMS = thapi_sampling_daemon
+
+nodist_thapi_sampling_daemon_SOURCES = \
 	$(SAMPLING_STATIC_PROBES_INCL)
 
-libThapiSampling_la_SOURCES = \
+thapi_sampling_daemon_SOURCES = \
 	thapi_sampling.h \
 	thapi_sampling.c
 
-libThapiSampling_la_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include $(LTTNG_UST_CFLAGS)
-libThapiSampling_la_LDFLAGS = -lpthread -version-info 1:0:0 $(LTTNG_UST_LIBS)
-libThapiSampling_la_LIBADD = libsamplingtracepoints.la
+thapi_sampling_daemon_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) -I$(top_srcdir)/utils/include $(LTTNG_UST_CFLAGS)
+thapi_sampling_daemon_LDFLAGS = -lpthread
+thapi_sampling_daemon_LDADD = libsamplingtracepoints.la
 
-samplingdir = $(pkglibdir)/sampling
-sampling_LTLIBRARIES = libThapiSampling.la
-
+CLEANFILES += $(bin_PROGRAMS)

--- a/sampling/thapi_sampling.c
+++ b/sampling/thapi_sampling.c
@@ -7,13 +7,20 @@
 #include "thapi_sampling.h"
 #include "sampling.h"
 #include "utarray.h"
+#include <signal.h>
+#include <time.h>
+
+#define RT_SIGNAL_READY (SIGRTMIN)
+#define RT_SIGNAL_FINISH (SIGRTMIN + 3)
 
 struct sampling_entry {
-  void (*pfn)(void);
+  void (*pfn_run)(void);
   struct timespec interval;
+  void (*pfn_final)(void);
   struct timespec next;
 };
 
+typedef void (*plugin_init_func)();
 
 static pthread_mutex_t thapi_sampling_mutex = PTHREAD_MUTEX_INITIALIZER;
 static UT_array *thapi_sampling_events = NULL;
@@ -21,18 +28,26 @@ static UT_array *thapi_sampling_events = NULL;
 static pthread_once_t thapi_init_once = PTHREAD_ONCE_INIT;
 static volatile int thapi_sampling_finished = 0;
 static volatile int thapi_sampling_initialized = 0;
-static pthread_t thapi_sampling_thread;
+
+static void signal_handler_finish(int signum) {
+  printf("signal_handler_finish\n");
+  if (signum == RT_SIGNAL_FINISH) {
+    thapi_sampling_finished = 1;
+  }
+}
 
 static void __attribute__((destructor))
 thapi_sampling_cleanup() {
   if (!thapi_sampling_initialized)
     return;
   thapi_sampling_finished = 1;
-  pthread_join(thapi_sampling_thread, NULL);
   pthread_mutex_lock(&thapi_sampling_mutex);
   struct sampling_entry **entry = NULL;
-  while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry)))
+  while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry))) {
+    if ( (*entry)->pfn_final )
+        (*entry)->pfn_final();
     free(*entry);
+  }
   utarray_free(thapi_sampling_events);
   pthread_mutex_unlock(&thapi_sampling_mutex);
 }
@@ -66,7 +81,7 @@ static inline void time_add(struct timespec *dest, const struct timespec *t, con
   }
 }
 
-void * thapi_sampling_loop(void *args) {
+static void * thapi_sampling_loop(void *args) {
   (void)args;
   while(!thapi_sampling_finished) {
     struct timespec now;
@@ -76,7 +91,7 @@ void * thapi_sampling_loop(void *args) {
     clock_gettime(CLOCK_REALTIME, &now);
     while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry)) &&
            time_cmp(&(*entry)->next, &now) < 0) {
-      (*entry)->pfn();
+      (*entry)->pfn_run();
       time_add(&(*entry)->next, &(*entry)->next, &(*entry)->interval);
       if(time_cmp(&(*entry)->next, &now) < 0)
 	      time_add(&(*entry)->next, &now, &(*entry)->interval);
@@ -92,43 +107,39 @@ void * thapi_sampling_loop(void *args) {
 }
 
 static void thapi_sampling_heartbeat() {
+  printf("thapi_sampling\n");
   do_tracepoint(lttng_ust_sampling, heartbeat, 16);
 }
 
+static void thapi_sampling_heartbeat_finalize() {
+   printf("thapi_sampling_finalize\n");
+   do_tracepoint(lttng_ust_sampling, heartbeat, 32);
+}
+
 static void thapi_sampling_heartbeat2() {
+  printf("thapi_sampling_heartbeat2\n");
   do_tracepoint(lttng_ust_sampling, heartbeat2);
 }
 
-void thapi_sampling_init_once() {
-  struct timespec interval;
+
+static void thapi_sampling_init_once() {
   utarray_new(thapi_sampling_events, &ut_ptr_icd);
   if (!thapi_sampling_events)
     return;
-  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT")) {
-    interval.tv_sec = 0;
-    interval.tv_nsec = 100000000;
-    thapi_register_sampling(&thapi_sampling_heartbeat, &interval);
-  }
-  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT2")) {
-    interval.tv_sec = 0;
-    interval.tv_nsec = 30000000;
-    thapi_register_sampling(&thapi_sampling_heartbeat2, &interval);
-  }
-  if (!pthread_create(&thapi_sampling_thread, NULL, &thapi_sampling_loop, NULL))
-    thapi_sampling_initialized = 1;
+  thapi_sampling_initialized = 1;
 }
 
-int thapi_sampling_init() {
-  if (getenv("LTTNG_UST_SAMPLING"))
-    pthread_once(&thapi_init_once, &thapi_sampling_init_once);
-  return 1;
+static int thapi_sampling_init() {
+  pthread_once(&thapi_init_once, &thapi_sampling_init_once);
+  return 0;
 }
 
-thapi_sampling_handle_t thapi_register_sampling(void (*pfn)(void), struct timespec *interval) {
+void thapi_register_sampling(void (*pfn_run)(void), struct timespec *interval,
+					        void (*pfn_final)(void) ) {
   struct sampling_entry *entry = NULL;
   struct timespec now, next;
   if(clock_gettime(CLOCK_REALTIME, &now))
-    return NULL;
+    return;
   time_add(&next, &now, interval);
 
   pthread_mutex_lock(&thapi_sampling_mutex);
@@ -137,30 +148,60 @@ thapi_sampling_handle_t thapi_register_sampling(void (*pfn)(void), struct timesp
   entry = (struct sampling_entry *)malloc(sizeof(struct sampling_entry));
   if (!entry)
     goto end;
-  entry->pfn = pfn;
+  entry->pfn_run = pfn_run;
   entry->interval = *interval;
+  entry->pfn_final = pfn_final;
+
   entry->next = next;
   utarray_push_back(thapi_sampling_events, &entry);
   utarray_sort(thapi_sampling_events, sampling_entry_cmpw);
 end:
   pthread_mutex_unlock(&thapi_sampling_mutex);
-  return entry;
+  return;
 }
 
-void thapi_unregister_sampling(thapi_sampling_handle_t handle)
-{
-  if (!handle)
-    return;
-  struct sampling_entry *entry = (struct sampling_entry *)handle;
-  pthread_mutex_lock(&thapi_sampling_mutex);
-  unsigned int len = utarray_len(thapi_sampling_events);
-  for (unsigned int i = 0; i < len; i++) {
-    struct sampling_entry **p =
-      (struct sampling_entry **)utarray_eltptr(thapi_sampling_events, i);
-    if (*p == entry) {
-      utarray_erase(thapi_sampling_events, i, 1);
-      break;
-    }
+int main(int argc, char **argv) {
+
+  int parent_pid = 0;
+  parent_pid = atoi(argv[1]);
+   
+  // Setup signaling, to exist the sampling loop
+  sigset_t signal_set;
+  sigemptyset(&signal_set);
+  sigaddset(&signal_set, RT_SIGNAL_FINISH);
+  signal(RT_SIGNAL_FINISH, signal_handler_finish);
+
+  // Initlixaztion
+  thapi_sampling_init();
+
+  // Register test sample    
+  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT")) {
+    struct timespec interval;
+    interval.tv_sec = 1;
+    interval.tv_nsec = 100000000;
+    thapi_register_sampling(&thapi_sampling_heartbeat, &interval, &thapi_sampling_heartbeat_finalize);
   }
-  pthread_mutex_unlock(&thapi_sampling_mutex);
+  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT2")) {
+    struct timespec interval;
+    interval.tv_sec = 2;
+    interval.tv_nsec = 30000000;
+    thapi_register_sampling(&thapi_sampling_heartbeat2, &interval, NULL);
+  }
+
+  // Regiser user sample
+  for (int i=2 ; i < argc; i++) {
+     void *handle = dlopen(argv[i], RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+     plugin_init_func f = (plugin_init_func)(intptr_t)dlsym(handle, "thapi_register_sampling_plugin");
+     f();
+  }
+
+  // Signal Ready to manager
+  kill(parent_pid, RT_SIGNAL_READY);
+
+  // Run until signal is comming
+  thapi_sampling_loop(NULL);
+  // Call destructor
+  kill(parent_pid, RT_SIGNAL_READY);
+
+    return 0;
 }

--- a/sampling/thapi_sampling.c
+++ b/sampling/thapi_sampling.c
@@ -1,17 +1,9 @@
-#include <stdlib.h>
 #include <pthread.h>
-#include <unistd.h>
-#include <time.h>
-#include <inttypes.h>
-#include <stdio.h>
+// Define both header
 #include "thapi_sampling.h"
-#include "sampling.h"
+#include "thapi_sampling_register.h"
 #include "utarray.h"
-#include <signal.h>
 #include <time.h>
-
-#define RT_SIGNAL_READY (SIGRTMIN)
-#define RT_SIGNAL_FINISH (SIGRTMIN + 3)
 
 struct sampling_entry {
   void (*pfn_run)(void);
@@ -20,39 +12,30 @@ struct sampling_entry {
   struct timespec next;
 };
 
-typedef void (*plugin_init_func)();
-
 static pthread_mutex_t thapi_sampling_mutex = PTHREAD_MUTEX_INITIALIZER;
 static UT_array *thapi_sampling_events = NULL;
 
 static pthread_once_t thapi_init_once = PTHREAD_ONCE_INIT;
-static volatile int thapi_sampling_finished = 0;
+
 static volatile int thapi_sampling_initialized = 0;
+volatile int thapi_sampling_finished = 0;
 
-static void signal_handler_finish(int signum) {
-  printf("signal_handler_finish\n");
-  if (signum == RT_SIGNAL_FINISH) {
-    thapi_sampling_finished = 1;
-  }
-}
-
-static void __attribute__((destructor))
-thapi_sampling_cleanup() {
+static void __attribute__((destructor)) thapi_sampling_cleanup() {
   if (!thapi_sampling_initialized)
     return;
   thapi_sampling_finished = 1;
   pthread_mutex_lock(&thapi_sampling_mutex);
   struct sampling_entry **entry = NULL;
   while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry))) {
-    if ( (*entry)->pfn_final )
-        (*entry)->pfn_final();
+    if ((*entry)->pfn_final)
+      (*entry)->pfn_final();
     free(*entry);
   }
   utarray_free(thapi_sampling_events);
   pthread_mutex_unlock(&thapi_sampling_mutex);
 }
 
-static inline int time_cmp(const struct timespec * t1, const struct timespec * t2) {
+static inline int time_cmp(const struct timespec *t1, const struct timespec *t2) {
   if (t1->tv_sec < t2->tv_sec)
     return -1;
   if (t1->tv_sec > t2->tv_sec)
@@ -64,15 +47,17 @@ static inline int time_cmp(const struct timespec * t1, const struct timespec * t
   return 0;
 }
 
-static inline int sampling_entry_cmp(const struct sampling_entry **e1, const struct sampling_entry **e2) {
+static inline int sampling_entry_cmp(const struct sampling_entry **e1,
+                                     const struct sampling_entry **e2) {
   return time_cmp(&(*e1)->next, &(*e2)->next);
 }
 
-static inline int sampling_entry_cmpw(const void * t1, const void * t2) {
+static inline int sampling_entry_cmpw(const void *t1, const void *t2) {
   return sampling_entry_cmp((const struct sampling_entry **)t1, (const struct sampling_entry **)t2);
 }
 
-static inline void time_add(struct timespec *dest, const struct timespec *t, const struct timespec *d) {
+static inline void time_add(struct timespec *dest, const struct timespec *t,
+                            const struct timespec *d) {
   dest->tv_nsec = t->tv_nsec + d->tv_nsec;
   dest->tv_sec = t->tv_sec + d->tv_sec;
   while (dest->tv_nsec > 999999999) {
@@ -81,64 +66,11 @@ static inline void time_add(struct timespec *dest, const struct timespec *t, con
   }
 }
 
-static void * thapi_sampling_loop(void *args) {
-  (void)args;
-  while(!thapi_sampling_finished) {
-    struct timespec now;
-    struct sampling_entry **entry = NULL;
-
-    pthread_mutex_lock(&thapi_sampling_mutex);
-    clock_gettime(CLOCK_REALTIME, &now);
-    while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry)) &&
-           time_cmp(&(*entry)->next, &now) < 0) {
-      (*entry)->pfn_run();
-      time_add(&(*entry)->next, &(*entry)->next, &(*entry)->interval);
-      if(time_cmp(&(*entry)->next, &now) < 0)
-	      time_add(&(*entry)->next, &now, &(*entry)->interval);
-    }
-    utarray_sort(thapi_sampling_events, sampling_entry_cmpw);
-    entry = (struct sampling_entry **)utarray_front(thapi_sampling_events);
-    pthread_mutex_unlock(&thapi_sampling_mutex);
-    if (entry)
-      while (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &(*entry)->next, NULL) && !thapi_sampling_finished) 
-        ;
-  }
-  return NULL;
-}
-
-static void thapi_sampling_heartbeat() {
-  printf("thapi_sampling\n");
-  do_tracepoint(lttng_ust_sampling, heartbeat, 16);
-}
-
-static void thapi_sampling_heartbeat_finalize() {
-   printf("thapi_sampling_finalize\n");
-   do_tracepoint(lttng_ust_sampling, heartbeat, 32);
-}
-
-static void thapi_sampling_heartbeat2() {
-  printf("thapi_sampling_heartbeat2\n");
-  do_tracepoint(lttng_ust_sampling, heartbeat2);
-}
-
-
-static void thapi_sampling_init_once() {
-  utarray_new(thapi_sampling_events, &ut_ptr_icd);
-  if (!thapi_sampling_events)
-    return;
-  thapi_sampling_initialized = 1;
-}
-
-static int thapi_sampling_init() {
-  pthread_once(&thapi_init_once, &thapi_sampling_init_once);
-  return 0;
-}
-
 void thapi_register_sampling(void (*pfn_run)(void), struct timespec *interval,
-					        void (*pfn_final)(void) ) {
+                             void (*pfn_final)(void)) {
   struct sampling_entry *entry = NULL;
   struct timespec now, next;
-  if(clock_gettime(CLOCK_REALTIME, &now))
+  if (clock_gettime(CLOCK_REALTIME, &now))
     return;
   time_add(&next, &now, interval);
 
@@ -160,48 +92,40 @@ end:
   return;
 }
 
-int main(int argc, char **argv) {
+void *thapi_sampling_loop(void *args) {
+  (void)args;
+  while (!thapi_sampling_finished) {
+    struct timespec now;
+    struct sampling_entry **entry = NULL;
 
-  int parent_pid = 0;
-  parent_pid = atoi(argv[1]);
-   
-  // Setup signaling, to exist the sampling loop
-  sigset_t signal_set;
-  sigemptyset(&signal_set);
-  sigaddset(&signal_set, RT_SIGNAL_FINISH);
-  signal(RT_SIGNAL_FINISH, signal_handler_finish);
-
-  // Initlixaztion
-  thapi_sampling_init();
-
-  // Register test sample    
-  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT")) {
-    struct timespec interval;
-    interval.tv_sec = 1;
-    interval.tv_nsec = 100000000;
-    thapi_register_sampling(&thapi_sampling_heartbeat, &interval, &thapi_sampling_heartbeat_finalize);
+    pthread_mutex_lock(&thapi_sampling_mutex);
+    clock_gettime(CLOCK_REALTIME, &now);
+    while ((entry = (struct sampling_entry **)utarray_next(thapi_sampling_events, entry)) &&
+           time_cmp(&(*entry)->next, &now) < 0) {
+      (*entry)->pfn_run();
+      time_add(&(*entry)->next, &(*entry)->next, &(*entry)->interval);
+      if (time_cmp(&(*entry)->next, &now) < 0)
+        time_add(&(*entry)->next, &now, &(*entry)->interval);
+    }
+    utarray_sort(thapi_sampling_events, sampling_entry_cmpw);
+    entry = (struct sampling_entry **)utarray_front(thapi_sampling_events);
+    pthread_mutex_unlock(&thapi_sampling_mutex);
+    if (entry)
+      while (clock_nanosleep(CLOCK_REALTIME, TIMER_ABSTIME, &(*entry)->next, NULL) &&
+             !thapi_sampling_finished)
+        ;
   }
-  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT2")) {
-    struct timespec interval;
-    interval.tv_sec = 2;
-    interval.tv_nsec = 30000000;
-    thapi_register_sampling(&thapi_sampling_heartbeat2, &interval, NULL);
-  }
+  return NULL;
+}
 
-  // Regiser user sample
-  for (int i=2 ; i < argc; i++) {
-     void *handle = dlopen(argv[i], RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
-     plugin_init_func f = (plugin_init_func)(intptr_t)dlsym(handle, "thapi_register_sampling_plugin");
-     f();
-  }
+static void thapi_sampling_init_once() {
+  utarray_new(thapi_sampling_events, &ut_ptr_icd);
+  if (!thapi_sampling_events)
+    return;
+  thapi_sampling_initialized = 1;
+}
 
-  // Signal Ready to manager
-  kill(parent_pid, RT_SIGNAL_READY);
-
-  // Run until signal is comming
-  thapi_sampling_loop(NULL);
-  // Call destructor
-  kill(parent_pid, RT_SIGNAL_READY);
-
-    return 0;
+int thapi_sampling_init() {
+  pthread_once(&thapi_init_once, &thapi_sampling_init_once);
+  return 0;
 }

--- a/sampling/thapi_sampling.h
+++ b/sampling/thapi_sampling.h
@@ -1,14 +1,5 @@
-#include <time.h>
-
-typedef void * thapi_sampling_handle_t;
-
-extern int thapi_sampling_init();
-
-extern thapi_sampling_handle_t
-thapi_register_sampling(
-	void (*pfn)(void),
-	struct timespec *interval);
-
 extern void
-thapi_unregister_sampling(
-	thapi_sampling_handle_t handle);
+thapi_register_sampling(
+	void (*pfn_run)(void) /*Running*/,
+	struct timespec *interval,
+	void (*pfn_final)(void) /*Finalization*/);

--- a/sampling/thapi_sampling.h
+++ b/sampling/thapi_sampling.h
@@ -1,5 +1,6 @@
-extern void
-thapi_register_sampling(
-	void (*pfn_run)(void) /*Running*/,
-	struct timespec *interval,
-	void (*pfn_final)(void) /*Finalization*/);
+#pragma once
+
+extern volatile int thapi_sampling_finished;
+
+int thapi_sampling_init();
+void *thapi_sampling_loop(void *args);

--- a/sampling/thapi_sampling_daemon.c
+++ b/sampling/thapi_sampling_daemon.c
@@ -1,0 +1,80 @@
+#include "thapi_sampling.h"
+#include "thapi_sampling_register.h"
+#include <dlfcn.h>
+#include <inttypes.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
+// Lttng tracepoint for hearbeat
+#include "sampling.h"
+
+#define RT_SIGNAL_READY (SIGRTMIN)
+#define RT_SIGNAL_FINISH (SIGRTMIN + 3)
+
+static void thapi_sampling_heartbeat() {
+  do_tracepoint(lttng_ust_sampling, heartbeat, 16);
+}
+
+static void thapi_sampling_heartbeat_finalize() {
+  do_tracepoint(lttng_ust_sampling, heartbeat, 32);
+}
+
+static void thapi_sampling_heartbeat2() {
+  do_tracepoint(lttng_ust_sampling, heartbeat2);
+}
+
+typedef void (*plugin_init_func)();
+
+static void signal_handler_finish(int signum) {
+  if (signum == RT_SIGNAL_FINISH) {
+    thapi_sampling_finished = 1;
+  }
+}
+
+int main(int argc, char **argv) {
+
+  int parent_pid = 0;
+  parent_pid = atoi(argv[1]);
+
+  // Setup signaling, to exist the sampling loop
+  sigset_t signal_set;
+  sigemptyset(&signal_set);
+  sigaddset(&signal_set, RT_SIGNAL_FINISH);
+  signal(RT_SIGNAL_FINISH, signal_handler_finish);
+
+  // Initlixaztion
+  thapi_sampling_init();
+
+  // Register test sample.
+  // TODO: Should be moved in their "sampling_test.so"
+  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT")) {
+    struct timespec interval;
+    interval.tv_sec = 1;
+    interval.tv_nsec = 100000000;
+    thapi_register_sampling(&thapi_sampling_heartbeat, &interval,
+                            &thapi_sampling_heartbeat_finalize);
+  }
+  if (getenv("LTTNG_UST_SAMPLING_HEARTBEAT2")) {
+    struct timespec interval;
+    interval.tv_sec = 2;
+    interval.tv_nsec = 30000000;
+    thapi_register_sampling(&thapi_sampling_heartbeat2, &interval, NULL);
+  }
+  // Regiser user sample
+  for (int i = 2; i < argc; i++) {
+    void *handle = dlopen(argv[i], RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    plugin_init_func f =
+        (plugin_init_func)(intptr_t)dlsym(handle, "thapi_register_sampling_plugin");
+    f();
+  }
+  // Signal Ready to manager
+  kill(parent_pid, RT_SIGNAL_READY);
+  // Run until signal is comming
+  thapi_sampling_loop(NULL);
+  // Call destructor
+  kill(parent_pid, RT_SIGNAL_READY);
+
+  return 0;
+}

--- a/sampling/thapi_sampling_register.h
+++ b/sampling/thapi_sampling_register.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "time.h"
+void thapi_register_sampling(void (*pfn_run)(void), struct timespec *interval,
+                             void (*pfn_final)(void));

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -384,13 +384,13 @@ class SamplingDaemon < SpawnDaemon
     lazy_exec(message, sampling?, &block)
   end
 
-  def initialize(h = {})
-    daemon_path = "#{BINDIR}/sampling_daemon"
+  def initialize(h = {}, path_so = "")
+    daemon_path = "#{BINDIR}/thapi_sampling_daemon"
     raise "No sampling_daemon binary found at #{daemon_path}" unless File.exist?(daemon_path)
 
-    LOGGER.debug { "spawn(sampling_daemon) #{Process.pid})" }
+    LOGGER.debug { "spawn(sampling_daemon) #{Process.pid} #{path_so}" }
     lazy_exec_sampling('Initialize SamplingDaemon') do
-      @pid = spawn(h, "#{daemon_path} #{Process.pid}")
+      @pid = spawn(h, "#{daemon_path} #{Process.pid} #{path_so}")
     end
   end
 
@@ -475,8 +475,18 @@ def env_tracers
   end
   # Usr Apps need to be launched with this to support blocking.
   h['LTTNG_UST_ALLOW_BLOCKING'] = 1
+
   # Customization
-  h['LTTNG_UST_ZE_PARANOID_DRIFT'] = 1 if OPTIONS[:'backend-names'].include?('ze') && OPTIONS[:profile]
+  if OPTIONS[:'backend-names'].include?('ze')
+    h['LTTNG_UST_ZE_PARANOID_DRIFT'] = 1 if OPTIONS[:profile]
+    if sampling?
+      # The current only reliable way to use zes api
+      #   is to call zesInit and set ZES_ENABLE_SYSMAN to 0
+      h['ZES_ENABLE_SYSMAN'] = 0
+      h['LTTNG_UST_ZE_SAMPLING_ENERGY'] = 1
+      h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'ze', 'libzesampling.so')
+    end
+  end
   if OPTIONS[:'backend-names'].include?('omp')
     backends << 'omp'
     h['OMP_TOOL_LIBRARIES'] = File.join(LIBDIR, 'libTracerOMPT.so')
@@ -486,10 +496,6 @@ def env_tracers
   if sampling?
     LOGGER.debug('Sampling Enabled')
     h['LTTNG_UST_SAMPLING'] = 1
-    h['LTTNG_UST_SAMPLING_ENERGY'] = 1
-    # The current only reliable way to use zes api
-    #   is to call zesInit and set ZES_ENABLE_SYSMAN to 0
-    h['ZES_ENABLE_SYSMAN'] = 0 if OPTIONS[:'backend-names'].include?('ze')
     h[%w[LD_LIBRARY_PATH prepend]] << File.join(PKGLIBDIR, 'sampling')
   end
 
@@ -784,6 +790,9 @@ def trace_and_on_node_processing(usr_argv)
     # for the early exiting ranks
     return unless mpi_local_master?
 
+    # Finalize sampling daemon
+    sampling_daemon.finalize
+
     # Stop Lttng session and babeltrace daemons
     lm_lttng_teardown_session
     if OPTIONS[:archive]
@@ -795,7 +804,6 @@ def trace_and_on_node_processing(usr_argv)
     end
     # we can kill the session daemon
     lm_lttng_kill_sessiond
-    sampling_daemon.finalize
   end
 
   SyncDaemon.open do |syncd|
@@ -811,7 +819,7 @@ def trace_and_on_node_processing(usr_argv)
              lm_babeltrace(backends) if OPTIONS[:archive]
            end
     # Spawn sampling daemon before starting user apps
-    sampling_daemon = SamplingDaemon.new(h)
+    sampling_daemon = SamplingDaemon.new(h, h['THAPI_SAMPLING_LIBRARIES'])
 
     syncd.local_barrier('waiting_for_lttng_setup')
 

--- a/ze/Makefile.am
+++ b/ze/Makefile.am
@@ -149,17 +149,15 @@ BUILT_SOURCES = \
 	$(ZE_PROBES_INCL) \
 	$(ZE_STATIC_PROBES_INCL)
 
-bin_PROGRAMS = sampling_daemon
+libzesampling_la_SOURCES = ze_sampling_plugin.c
 
-sampling_daemon_SOURCES = sampling_daemon.c
-
-nodist_sampling_daemon_SOURCES = \
+nodist_libzesampling_la_SOURCES = \
 	$(ZE_PROBES_INCL) \
 	$(ZE_STATIC_PROBES_INCL)
 
-sampling_daemon_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I$(top_srcdir)/sampling -I$(top_srcdir)/ze/include -I./
-sampling_daemon_CFLAGS = -Wall -Wextra $(WERROR) $(LTTNG_UST_CFLAGS)
-sampling_daemon_LDADD = libzetracepoints.la -ldl -lpthread $(LTTNG_UST_LIBS) ../sampling/libThapiSampling.la
+libzesampling_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I$(top_srcdir)/sampling -I$(top_srcdir)/ze/include -I./
+libzesampling_la_CFLAGS = -Wall -Wextra $(WERROR) $(LTTNG_UST_CFLAGS)
+libzesampling_la_LIBADD =  ../sampling/libThapiSampling.la libzetracepoints.la -ldl $(LTTNG_UST_LIBS)
 
 tracer_ze.c: $(srcdir)/gen_ze.rb $(srcdir)/tracer_ze_helpers.include.c $(srcdir)/ze.h.include $(ZE_MODEL) $(ZE_PROBES_INCL) $(ZE_STATIC_PROBES_INCL)
 	SRC_DIR=$(srcdir) $(RUBY) $< > $@
@@ -168,7 +166,7 @@ EXTRA_DIST += \
 	gen_ze.rb \
 	tracer_ze_helpers.include.c
 
-CLEANFILES += tracer_ze.c sampling_daemon
+CLEANFILES += tracer_ze.c
 
 bin_SCRIPTS = \
 	tracer_ze.sh
@@ -186,7 +184,7 @@ libzetracepoints_la_CFLAGS = -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-type
 libzetracepoints_la_LDFLAGS = $(LTTNG_UST_LIBS)
 
 zedir = $(pkglibdir)/ze
-ze_LTLIBRARIES = libze_loader.la
+ze_LTLIBRARIES = libze_loader.la libzesampling.la
 
 bt2dir = $(pkglibdir)/bt2
 bt2_LTLIBRARIES = libZEInterval.la

--- a/ze/ze_sampling_plugin.c
+++ b/ze/ze_sampling_plugin.c
@@ -1,15 +1,15 @@
-#include "thapi_sampling.h"
+#include "thapi_sampling_register.h"
 #include "ze_build.h"
 #include "ze_sampling.h"
 #include <dlfcn.h>
 #include <errno.h>
 #include <ffi.h>
-#include <signal.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <time.h>
 #include <unistd.h>
 
 #define RT_SIGNAL_READY (SIGRTMIN)
@@ -222,7 +222,6 @@ static void find_ze_symbols(void *handle, int verbose) {
   if (!ZES_MEMORY_GET_BANDWIDTH_PTR && verbose)
     fprintf(stderr, "Missing symbol zesMemoryGetBandwidth!\n");
 }
-volatile bool running = true;
 static int _sampling_freq_initialized = 0;
 static int _sampling_fabricPorts_initialized = 0;
 static int _sampling_memModules_initialized = 0;
@@ -719,46 +718,33 @@ static void thapi_sampling_energy() {
   }
 }
 
-void signal_handler_finish(int signum) {
-  if (signum == RT_SIGNAL_FINISH) {
-    running = false;
-  }
+static void *handle = NULL;
+
+static void finalize(void) {
+  if (handle)
+    dlclose(handle);
 }
 
-int main(int argc, char **argv) {
-
-  int parent_pid = 0;
-  if (argc < 2) {
-    _USAGE_MSG("<parent_pid>", argv[0]);
-    return 1;
-  }
-  parent_pid = atoi(argv[1]);
-  if (parent_pid <= 0) {
-    _ERROR_MSG("Invalid or missing parent PID.");
-    return 1;
-  }
-
-  thapi_sampling_init(); // Initialize sampling (also starts sampling thread)
-  void *handle = NULL;
+void thapi_register_sampling_plugin(void) {
   {
-    char *s = getenv("LTTNG_UST_SAMPLING_ENERGY");
+    char *s = getenv("LTTNG_UST_ZE_SAMPLING_ENERGY");
     if (!s || strcmp(s, "0") == 0)
-      goto bypass;
+      return;
   }
+  {
+    // Load necessary libraries
+    char *s = getenv("LTTNG_UST_ZE_LIBZE_LOADER");
+    if (s) {
+      handle = dlopen(s, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    } else {
+      handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    }
 
-  // Load necessary libraries
-  char *s = getenv("LTTNG_UST_ZE_LIBZE_LOADER");
-  if (s) {
-    handle = dlopen(s, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
-  } else {
-    handle = dlopen("libze_loader.so", RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    if (!handle) {
+      _DL_ERROR_MSG();
+      return;
+    }
   }
-
-  if (!handle) {
-    _DL_ERROR_MSG();
-    return 1;
-  }
-
   // Find zes symbols
   int verbose = 0;
   find_ze_symbols(handle, verbose);
@@ -768,26 +754,8 @@ int main(int argc, char **argv) {
 
   // register L0 sampler exactly once
   {
-    struct timespec interval = { .tv_sec = 0, .tv_nsec = 50000000 }; /* 50 ms */
-    thapi_register_sampling(&thapi_sampling_energy, &interval);
+    struct timespec interval = {.tv_sec = 0, .tv_nsec = 50000000}; /* 50 ms */
+    thapi_register_sampling(&thapi_sampling_energy, &interval, &finalize);
   }
-
-bypass:
-  // Run the signal loop
-  signal(RT_SIGNAL_FINISH, signal_handler_finish);
-
-  if (kill(parent_pid, RT_SIGNAL_READY) != 0) {
-    _ERROR_MSG("Failed to send READY signal to parent");
-  }
-
-  // Wait for RT_SIGNAL_FINISH to flip `running = false`
-  while (running) {
-    pause();
-  }
-
-  if (handle)
-    dlclose(handle);
-  if (parent_pid != 0)
-    kill(parent_pid, RT_SIGNAL_READY);
-  return 0;
+  return;
 }


### PR DESCRIPTION
So the diff is bigger than expected because I'm stupid but, in short the change are small.

We now have one `thapi_sampling_daemon`, who can open some `libThapiSamplingPluging.so`. `libThapiSamplingPluging` just need to expose a `thapi_register_sampling_plugin`  function, and inside call `thapi_register_sampling`.

In short we:
- Introduce `libThapiSampling.so`
     - Expose only 3 symbols, the `register`, `init`, and `sampling_loop`
- Introduce `thapi_sampling_register.h` header, exposing only `register`, the only header than sampling plugin need
- Introduce `thapi_sampling.h` for the `thapi_sampling_daemon` so `sampling_loop` and `init`.


This will help nathan and is new CXI plugin sample.

In the futur we can maybe clean `thapi_sampling_daemon` (we don't need pthread protection anymore) and the `ze_sampling_pluging` (no need to dl_open anymore, we can just call directly the pointers)