### PR TITLE
Use default values for test env vars

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -99,9 +99,6 @@ jobs:
     if: ${{ success() }}
     name: Integration ${{ matrix.bats_file }} ${{matrix.thapi_sync_daemon }}
     runs-on: ubuntu-24.04
-    env:
-      THAPI_TEST_BIN: clinfo
-      THAPI_BIN_DIR: ./build/ici/bin
     steps:
       - uses: actions/checkout@v4
       - uses: mpi4py/setup-mpi@v1

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -118,7 +118,7 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
       - name: Integration test
         run: |
-          bats integration_tests/
+          THAPI_BIN_DIR=./build/ici/bin bats integration_tests/
 
   build-in-tree-and-check:
     needs: efficios_dep

--- a/integration_tests/abnormal_usr_bin_exit.bats
+++ b/integration_tests/abnormal_usr_bin_exit.bats
@@ -1,7 +1,5 @@
 bats_require_minimum_version 1.5.0
 
-load test_env_vars.bash
-
 @test "exit_code_propagated" {
    run -55 $IPROF -- bash -c "exit 55"
    run -55 $IPROF --no-analysis -- bash -c "exit 55"

--- a/integration_tests/abnormal_usr_bin_exit.bats
+++ b/integration_tests/abnormal_usr_bin_exit.bats
@@ -1,10 +1,6 @@
 bats_require_minimum_version 1.5.0
 
-setup_file() {
-   export THAPI_HOME=$PWD
-   export IPROF=$THAPI_BIN_DIR/iprof
-   export MPIRUN=${MPIRUN:-mpirun}
-}
+load test_env_vars.bash
 
 @test "exit_code_propagated" {
    run -55 $IPROF -- bash -c "exit 55"

--- a/integration_tests/backend_mpi.bats
+++ b/integration_tests/backend_mpi.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-load test_env_vars.bash
-
 @test "backend_mpi_sanity_check" {
    mpicc ./integration_tests/mpi_helloworld.c -o mpi_helloworld
    $IPROF --backends mpi --analysis-output out.txt -- ./mpi_helloworld

--- a/integration_tests/backend_mpi.bats
+++ b/integration_tests/backend_mpi.bats
@@ -1,10 +1,6 @@
 #!/usr/bin/env bats
 
-setup_file() {
-   export THAPI_HOME=$PWD
-   export IPROF=$THAPI_BIN_DIR/iprof
-   export MPIRUN=${MPIRUN:-mpirun}
-}
+load test_env_vars.bash
 
 @test "backend_mpi_sanity_check" {
    mpicc ./integration_tests/mpi_helloworld.c -o mpi_helloworld

--- a/integration_tests/general.bats
+++ b/integration_tests/general.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-load test_env_vars.bash
-
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces
 }

--- a/integration_tests/general.bats
+++ b/integration_tests/general.bats
@@ -1,9 +1,6 @@
 #!/usr/bin/env bats
 
-setup_file() {
-   export THAPI_HOME=$PWD
-   export IPROF=$THAPI_BIN_DIR/iprof
-}
+load test_env_vars.bash
 
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces

--- a/integration_tests/parallel_execution.bats
+++ b/integration_tests/parallel_execution.bats
@@ -1,11 +1,6 @@
 #!/usr/bin/env bats
 
-setup_file() {
-   export THAPI_HOME=$PWD
-   export IPROF=$THAPI_BIN_DIR/iprof
-   export BBT=$THAPI_BIN_DIR/babeltrace_thapi
-   export MPIRUN=${MPIRUN:-mpirun}
-}
+load test_env_vars.bash
 
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces

--- a/integration_tests/parallel_execution.bats
+++ b/integration_tests/parallel_execution.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-load test_env_vars.bash
-
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces
 }

--- a/integration_tests/sampling.bats
+++ b/integration_tests/sampling.bats
@@ -1,7 +1,5 @@
 #!/usr/bin/env bats
 
-load test_env_vars.bash
-
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces
 }

--- a/integration_tests/sampling.bats
+++ b/integration_tests/sampling.bats
@@ -1,6 +1,6 @@
-setup_file() {
-   export THAPI_HOME=$PWD
-}
+#!/usr/bin/env bats
+
+load test_env_vars.bash
 
 teardown_file() {
    rm -rf $THAPI_HOME/thapi-traces

--- a/integration_tests/setup_suite.bash
+++ b/integration_tests/setup_suite.bash
@@ -32,6 +32,13 @@ setup_suite() {
     missing_tools+=("babeltrace_thapi")
   fi
 
+  # Check for mpirun
+  if ! command -v "${MPIRUN}" >/dev/null 2>&1 && ! command -v mpirun >/dev/null 2>&1; then
+    echo "Error: 'mpirun' not found in PATH or at \$MPIRUN."
+    echo "-> Please set MPIRUN or add it to your PATH."
+    missing_tools+=("mpirun")
+  fi
+
   # Final summary
   if [ ${#missing_tools[@]} -eq 0 ]; then
     echo "All required tools are available."

--- a/integration_tests/setup_suite.bash
+++ b/integration_tests/setup_suite.bash
@@ -8,4 +8,35 @@ setup_suite() {
   export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}
   export BBT=${BBT:-${THAPI_BIN_DIR}/babeltrace_thapi}
   export MPIRUN=${MPIRUN:-mpirun}
+
+  missing_tools=()
+
+  # Check for clinfo
+  if ! command -v "${THAPI_TEST_BIN}" >/dev/null 2>&1 && ! command -v clinfo >/dev/null 2>&1; then
+    echo "Error: '${THAPI_TEST_BIN}' not found in PATH."
+    echo "-> Please install 'clinfo' or ensure it is in your PATH."
+    missing_tools+=("clinfo")
+  fi
+
+  # Check for iprof
+  if ! command -v "${IPROF}" >/dev/null 2>&1 && ! command -v iprof >/dev/null 2>&1; then
+    echo "Error: 'iprof' not found in PATH or at \$IPROF."
+    echo "-> Please set IPROF, set THAPI_BIN_DIR, or add it to your PATH."
+    missing_tools+=("iprof")
+  fi
+
+  # Check for babeltrace_thapi
+  if ! command -v "${BBT}" >/dev/null 2>&1 && ! command -v babeltrace_thapi >/dev/null 2>&1; then
+    echo "Error: 'babeltrace_thapi' not found in PATH or at \$BBT."
+    echo "-> Please set BBT, set THAPI_BIN_DIR, or add it to your PATH."
+    missing_tools+=("babeltrace_thapi")
+  fi
+
+  # Final summary
+  if [ ${#missing_tools[@]} -eq 0 ]; then
+    echo "All required tools are available."
+  else
+    echo "Missing tools: ${missing_tools[*]}"
+    exit 1
+  fi
 }

--- a/integration_tests/setup_suite.bash
+++ b/integration_tests/setup_suite.bash
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+setup_suite() {
+  export THAPI_HOME=${THAPI_HOME:-${PWD}}
+  export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${THAPI_HOME}/install/bin}
+  export THAPI_TEST_BIN=${THAPI_TEST_BIN:-clinfo}
+
+  export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}
+  export BBT=${BBT:-${THAPI_BIN_DIR}/babeltrace_thapi}
+  export MPIRUN=${MPIRUN:-mpirun}
+}

--- a/integration_tests/test_env_vars.bash
+++ b/integration_tests/test_env_vars.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export THAPI_HOME=${THAPI_HOME:-${PWD}}
-export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${PWD}/build/ici/bin}
+export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${THAPI_HOME}/install/bin}
 export THAPI_TEST_BIN=${THAPI_TEST_BIN:-clinfo}
 
 export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}

--- a/integration_tests/test_env_vars.bash
+++ b/integration_tests/test_env_vars.bash
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+export THAPI_HOME=${THAPI_HOME:-${PWD}}
+export THAPI_INSTALL_DIR=${THAPI_INSTALL_DIR:-${PWD}/build/ici}
+export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${THAPI_INSTALL_DIR}/bin}
+export THAPI_TEST_BIN=${THAPI_TEST_BIN:-clinfo}
+
+export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}
+export BBT=${BBT:-${THAPI_BIN_DIR}/babeltrace_thapi}
+export MPIRUN=${MPIRUN:-mpirun}

--- a/integration_tests/test_env_vars.bash
+++ b/integration_tests/test_env_vars.bash
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 export THAPI_HOME=${THAPI_HOME:-${PWD}}
-export THAPI_INSTALL_DIR=${THAPI_INSTALL_DIR:-${PWD}/build/ici}
-export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${THAPI_INSTALL_DIR}/bin}
+export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${PWD}/build/ici/bin}
 export THAPI_TEST_BIN=${THAPI_TEST_BIN:-clinfo}
 
 export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}

--- a/integration_tests/test_env_vars.bash
+++ b/integration_tests/test_env_vars.bash
@@ -1,9 +1,0 @@
-#!/bin/bash
-
-export THAPI_HOME=${THAPI_HOME:-${PWD}}
-export THAPI_BIN_DIR=${THAPI_BIN_DIR:-${THAPI_HOME}/install/bin}
-export THAPI_TEST_BIN=${THAPI_TEST_BIN:-clinfo}
-
-export IPROF=${IPROF:-${THAPI_BIN_DIR}/iprof}
-export BBT=${BBT:-${THAPI_BIN_DIR}/babeltrace_thapi}
-export MPIRUN=${MPIRUN:-mpirun}


### PR DESCRIPTION
Also, set all the env vars in a common file. This will make it easier to run tests manually
and through spack in the future.