### PR TITLE
Support BT2.1 and formating

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -82,7 +82,6 @@ module BTComponentClassRefinement
     def add(component_class, name, params: {},
             logging_level: BT2::BTLogging.default_level,
             initialize_method_data: nil)
-
       @plugins_path << component_class.plugin.path
       @cli_v << "--component #{name}:#{component_class.type.to_s.split('_').last.downcase}.#{component_class.plugin.name}.#{component_class.name}"
 
@@ -224,10 +223,12 @@ def get_and_add_components(graph, names, l_inputs)
       end
       s
     when 'sink.ctf.fs'
-      graph.add(comp, 'ctf_sink',
-                params: { 'path' => $options[:output],
-                          'assume-single-trace' => false,
-                          'quiet' => $options[:debug] ? false : true })
+
+      params = { 'path' => $options[:output],
+                 'assume-single-trace' => false,
+                 'quiet' => $options[:debug] ? false : true }
+      params['ctf-version'] = '1.8' if BT2.bt_version_get_major >= 2 && BT2.bt_version_get_minor >= 1
+      graph.add(comp, 'ctf_sink', params: params)
     when 'sink.btx_tally.tally'
       graph.add(comp, 'tally',
                 params: { 'display' => $options[:display],
@@ -265,9 +266,9 @@ THAPI_METADATA_FILE = 'thapi_metadata.yaml'
 
 def thapi_metadata(trace)
   @thapi_metadata ||= {}
-  full_path =  File.join(trace, THAPI_METADATA_FILE)
+  full_path = File.join(trace, THAPI_METADATA_FILE)
   unless File.file?(full_path)
-    STDERR.puts("Error: #{trace} isn't a valid trace (missing #{THAPI_METADATA_FILE})")
+    warn("Error: #{trace} isn't a valid trace (missing #{THAPI_METADATA_FILE})")
     exit(1)
   end
 
@@ -293,7 +294,7 @@ def bt_graphs(inputs)
     g_comps = [if $options[:live]
                  'source.ctf.lttng_live'
                elsif $options[:archive]
-                  'source.ctf.lttng_archive'
+                 'source.ctf.lttng_archive'
                else
                  'source.ctf.fs'
                end]
@@ -365,7 +366,7 @@ class BabeltraceParserThapi < OptionParserWithDefaultAndValidation
     on('-h', '--help', 'Prints this help') { print_help_and_exit(self, exit_code: 0) }
     on('-b', '--backends BACKENDS', Array, "Select which and how backends' need to handled.",
        'Format: backend_name[:backend_level],...',
-        default: ['mpi:3', 'omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1', 'cxi:4'])
+       default: ['mpi:3', 'omp:2', 'cl:1', 'ze:1', 'cuda:1', 'hip:1', 'cxi:4'])
     on('--debug', default: false)
     on('--archive SESSION-NAME')
     on('--archive-session-found-file-path PATH')

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -388,7 +388,7 @@ class SamplingDaemon < SpawnDaemon
     lazy_exec(message, sampling?, &block)
   end
 
-  def initialize(h = {}, path_so = "")
+  def initialize(h = {}, path_so = '')
     daemon_path = "#{BINDIR}/thapi_sampling_daemon"
     raise "No sampling_daemon binary found at #{daemon_path}" unless File.exist?(daemon_path)
 
@@ -496,11 +496,9 @@ def env_tracers
     h['OMP_TOOL_LIBRARIES'] = File.join(LIBDIR, 'libTracerOMPT.so')
   end
 
-  if OPTIONS[:'backend-names'].include?('cxi')
-    if sampling?
-      h['LTTNG_UST_CXI_SAMPLING_CXI'] = 1
-      h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'cxi', 'libCXISampling.so')
-    end
+  if OPTIONS[:'backend-names'].include?('cxi') && sampling?
+    h['LTTNG_UST_CXI_SAMPLING_CXI'] = 1
+    h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'cxi', 'libCXISampling.so')
   end
 
   # Sample
@@ -833,7 +831,7 @@ def trace_and_on_node_processing(usr_argv)
              lm_babeltrace(backends) if OPTIONS[:archive]
            end
     # Spawn sampling daemon before starting user apps
-    l_so = h.fetch('THAPI_SAMPLING_LIBRARIES','').gsub(':', ' ')
+    l_so = h.fetch('THAPI_SAMPLING_LIBRARIES', '').gsub(':', ' ')
     sampling_daemon = SamplingDaemon.new(h, l_so)
 
     syncd.local_barrier('waiting_for_lttng_setup')
@@ -898,6 +896,7 @@ def gm_processing(folder)
     fo.close
     _, status = Process.wait2(pid)
     raise "#{cmdname} #{args} failed" unless status.success?
+
     status
   end
 end


### PR DESCRIPTION
- Support BT2.1 ( need to pass `ctf=1.8` to ctf.sink.fs when BT >= 2.1)
- Run rubocop

I know, should Have not do everything on the same PR but I'm tired boss 

