### PR TITLE
Assume lttng trace when missing metadata

### DIFF
--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -272,13 +272,18 @@ THAPI_METADATA_FILE = 'thapi_metadata.yaml'
 
 def thapi_metadata(trace)
   @thapi_metadata ||= {}
-  full_path = File.join(trace, THAPI_METADATA_FILE)
-  unless File.file?(full_path)
-    warn("Error: #{trace} isn't a valid trace (missing #{THAPI_METADATA_FILE})")
-    exit(1)
-  end
+  return @thapi_metadata[trace] if @thapi_metadata.include?(trace)
 
-  @thapi_metadata[trace] ||= YAML.load_file(full_path)
+  full_path = File.join(trace, THAPI_METADATA_FILE)
+
+  data = if File.file?(full_path)
+           YAML.load_file(full_path)
+         else
+           warn("Warning: #{trace} isn't a valid trace (missing #{THAPI_METADATA_FILE}), we will assume a lttng trace")
+           { type: 'lttng' }
+         end
+
+  @thapi_metadata[trace] = data
 end
 
 def modify_metadata(command, trace)


### PR DESCRIPTION
Before the workflow:
```
$ tracer_ze.sh ze_info
$ iprof -r /home/applenco/lttng-traces/thapi-ze-session-20250908-231640
```
was broken due to 
```
Error: /home/applenco/lttng-traces/thapi-ze-session-20250908-231640 isn't a valid trace (missing thapi_metadata.yaml)
```

It will now print
```
$ iprof -r /home/applenco/lttng-traces/thapi-ze-session-20250908-232318
THAPI: Trace location: /home/applenco/lttng-traces/thapi-ze-session-20250908-232318
Warning: /home/applenco/lttng-traces/thapi-ze-session-20250908-232318 isn't a valid trace (missing thapi_metadata.yaml), we will assume a lttng trace
BACKEND_ZE | 1 Hostnames | 1 Processes | 1 Threads |

                        Name |    Time | Time(%) | Calls |  Average |    Min |    Max |
       zeDeviceGetProperties |  5.14us |  24.39% |     6 | 856.17ns |  447ns | 2.15us |
                      zeInit |  3.75us |  17.81% |     1 |   3.75us | 3.75us | 3.75us |
       zeDriverGetApiVersion |  3.33us |  15.81% |     2 |   1.66us |  204ns | 3.12us |
 zeDeviceGetModuleProperties |  3.29us |  15.62% |     6 | 548.17ns |  224ns | 1.78us |
                 zeDeviceGet |  1.92us |   9.10% |     2 | 958.00ns |  320ns | 1.60us |
zeDeviceGetComputeProperties |  1.73us |   8.21% |     6 | 288.17ns |  157ns |  606ns |
                 zeDriverGet |  1.59us |   7.54% |     2 | 793.50ns |  575ns | 1.01us |
       zeDriverGetProperties |   323ns |   1.53% |     1 | 323.00ns |  323ns |  323ns |
                       Total | 21.06us | 100.00% |    26 |
```

Fix #346 