### PR TITLE
Add `LTTng` import to `yaml_ast_lttng.rb`

### DIFF
--- a/utils/yaml_ast_lttng.rb
+++ b/utils/yaml_ast_lttng.rb
@@ -1,4 +1,5 @@
 require_relative './yaml_ast'
+require_relative './LTTng'
 
 FLOAT_SCALARS_MAP = {"float" => "uint32_t", "double" => "uint64_t"}
 


### PR DESCRIPTION
Before it was relying on some transient import.
It's required by `CustomType` who call `ev = LTTng::TracepointField::new`