### PR TITLE
[CUDA] Use RTLD_DEFAULT in dlsym to check for self open

### DIFF
--- a/backends/cuda/gen_cudart.rb
+++ b/backends/cuda/gen_cudart.rb
@@ -1,6 +1,8 @@
 require_relative 'cudart_model'
 
 puts <<EOF
+#define _GNU_SOURCE
+#include <dlfcn.h>
 #define __CUDA_API_VERSION_INTERNAL 1
 #include <cuda_runtime_api.h>
 #include <pthread.h>

--- a/backends/cuda/tracer_cudart_helpers.include.c
+++ b/backends/cuda/tracer_cudart_helpers.include.c
@@ -14,9 +14,10 @@ static void _load_tracer(void) {
       handle = dlopen("libcudart.so", RTLD_LAZY | RTLD_LOCAL);
   if (handle) {
     void* ptr = dlsym(handle, "cudaSetDevice");
-    if (ptr == (void*)&cudaSetDevice) { //opening oneself
-      dlclose(handle);
-      handle = NULL;
+    void* self = dlsym(RTLD_DEFAULT, "cudaSetDevice");
+    if (ptr == self) {  /* opening oneself */
+        dlclose(handle);
+        handle = NULL;
     }
   }
 


### PR DESCRIPTION
Fixes the symbol redefinition issue I was seeing by using RTLD_DEFAULT tells dlsym to fetch the same cudaSetDevice you’d get from a normal call at runtime.

My understanding is the first `dlsym(handle, "cudaSetDevice")` gets the address `cudaSetDevice` resolves to within the symbol scope and then by using `RTLD_DEFAULT` in the `dlsym(RTLD_DEFAULT, "cudaSetDevice")` call gives the address for the `cudaSetDevice` called within that translation unit. And then, you can just compare the two pointers to see if you are opening yourself.