### PR TITLE
Timeline generation: from global rank 0 to local rank 0 on each node 

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -774,25 +774,6 @@ def lm_babeltrace(backends)
     [pid_bt, pid_dirwatch]
   else
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
-
-    # if OPTIONS.include?(:timeline)
-    #   # if I could sync here it would be nice. then could pull from the FS
-    #   # get the timeline per node
-    #   # get hostname_id
-    #   hostname_string=Socket.gethostname
-    #   # get list of hostnames      
-    #   list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
-    #   # find index of hostname_string in list_hostnames
-    #   hostname_id = list_hostnames.find_index(hostname_string)
-    #   # compute the offset, based on splitting max_uint16_value by the number of hosts
-    #   max_uint16_value = (2**16) - 1
-    #   offset = (max_uint16_value / list_hostnames.length ) * hostname_id
-    #   backends = OPTIONS[:backends].join(',')
-    #   output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
-    #   args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
-    #   exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
-    # end
-
   end
 end
 
@@ -886,6 +867,8 @@ def trace_and_on_node_processing(usr_argv)
     # Preprocess trace
     unless OPTIONS[:archive]
       lm_babeltrace(backends)
+      # global barrier to ensure that all thapi_trace_dir_tmp are written per hostname.
+      # unless these directories are made previously
       syncd.global_barrier
       if OPTIONS.include?(:timeline)
         # get the timeline per node

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -192,33 +192,36 @@ def mpi_master?
   mpi_rank_id.zero?
 end
 
+MAX_INT32_VALUE = (2**31) - 1
 # returns an offset for each timeline file
 # this is based on chunking max_int32_value
 # into the number of nodes
 def get_offset
-  if not in_mpi_env?
-    # if not mpi, just return 0 offset
-    offset = 0
-  else
-    # if we launch with a scheduler, we can read from a hostfile.
-    hostfile=env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
-    if hostfile.nil?
-      max_int32_value = (2**31) - 1
-      # want to chunk by reasonable amount. for now, assume a max of 100000 nodes and
-      # chunk max_int32_value by that. So each node gets ~20000 spots 
-      offset = (max_int32_value / 100000) * (mpi_rank_id / mpi_local_size).floor
-    else
-      list_hostnames = File.readlines( hostfile ).map(&:chomp)
-      hostname_string=Socket.gethostname
-      # find index of hostname_string in list_hostnames
-      hostname_id = list_hostnames.find_index(hostname_string)
-      # compute the offset, based on splitting max_int32_value by the number of hosts
-      max_int32_value = (2**31) - 1
-      offset = (max_int32_value / list_hostnames.length ) * hostname_id
-    end
+  # if not mpi, just return 0 offset
+  return 0 unless in_mpi_env?
+  @get_offset ||= begin
+  # if we launch with a scheduler, we can read from a hostfile.
+  hostfile = env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
+  
+  # if there's a hostfile identified by the envs above,
+  # compute the offset, based on splitting MAX_INT32_VALUE by the number of hosts
+  # else want to chunk by reasonable amount. for now, assume a max of 10000 nodes and
+  # chunk MAX_INT32_VALUE by that. So each node gets ~200000 spots
+  number_hostname, hostname_index = if hostfile.nil?
+                                      [10_000, mpi_rank_id / mpi_local_size]
+                                    else
+                                      # splitting by "." in case the hostfile contains full hostnames with address
+                                      # (e.g. x4117c4s4b0n0.hsn.cm.aurora.alcf.anl.gov) and the Socket.gethostname is just x4117c4s4b0n0
+                                      list_hostnames = File.readlines(hostfile).map do |element|
+                                        element.split('.', 2).first
+                                      end
+                                      # find index of hostname_string in list_hostnames
+                                      hostname_id = list_hostnames.find_index(Socket.gethostname)
+                                      # compute the offset, based on splitting max_int32_value by the number of hosts
+                                      [list_hostnames.length, hostname_id]
+                                    end
+  (MAX_INT32_VALUE / number_hostname) * hostname_index
   end
-
-  return offset
 end
 
 #    _                    _
@@ -783,7 +786,7 @@ def lm_babeltrace(backends)
     if OPTIONS.include?(:timeline)
       offset=get_offset()        
       backends = OPTIONS[:backends].join(',')
-      output_per_host=File.join(thapi_trace_dir_tmp, "timeline_"+offset.to_s)
+      output_per_host=File.join(thapi_trace_dir_tmp, "timeline_"+offset.to_s+".pftrace")
       args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
       exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
       end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -192,16 +192,28 @@ def mpi_master?
   mpi_rank_id.zero?
 end
 
-def get_hostfile
+def get_hostnames
+  list_hostnames=[]
+  # first try via env
   hostfile=env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
-  # one alternative could be to list hostnames under parent(thapi_trace_dir_tmp)
   if hostfile.nil?
-    puts "Exiting from timeline, need a hostfile"
-    exit
+    # if nil, try via directory structure
+    Dir.entries(File.dirname(thapi_trace_dir_tmp)).sort.each do |entry|
+      if File.directory?(File.join(File.dirname(thapi_trace_dir_tmp), entry)) and entry != '.' and entry != '..'
+        list_hostnames.push(entry)
+      end
+    end
+  else
+    list_hostnames = File.readlines( hostfile ).map(&:chomp)
   end
-  return hostfile
+  # if list_names is still empty
+  if list_hostnames.empty?
+    puts "It looks like the hostfile is empty for some reason. Need to debug."
+    exit 1
+  end
+    
+  return list_hostnames
 end
-
 
 #    _                    _
 #   |_ _  |  _|  _  ._   |_) _. _|_ |_
@@ -763,22 +775,23 @@ def lm_babeltrace(backends)
   else
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
 
-    if OPTIONS.include?(:timeline)
-      # get the timeline per node
-      # get hostname_id
-      hostname_string=Socket.gethostname
-      # get list of hostnames      
-      list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
-      # find index of hostname_string in list_hostnames
-      hostname_id = list_hostnames.find_index(hostname_string)
-      # compute the offset, based on splitting max_uint16_value by the number of hosts
-      max_uint16_value = (2**16) - 1
-      offset = (max_uint16_value / list_hostnames.length ) * hostname_id
-      backends = OPTIONS[:backends].join(',')
-      output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
-      args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
-      exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
-    end
+    # if OPTIONS.include?(:timeline)
+    #   # if I could sync here it would be nice. then could pull from the FS
+    #   # get the timeline per node
+    #   # get hostname_id
+    #   hostname_string=Socket.gethostname
+    #   # get list of hostnames      
+    #   list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
+    #   # find index of hostname_string in list_hostnames
+    #   hostname_id = list_hostnames.find_index(hostname_string)
+    #   # compute the offset, based on splitting max_uint16_value by the number of hosts
+    #   max_uint16_value = (2**16) - 1
+    #   offset = (max_uint16_value / list_hostnames.length ) * hostname_id
+    #   backends = OPTIONS[:backends].join(',')
+    #   output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
+    #   args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
+    #   exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
+    # end
 
   end
 end
@@ -873,6 +886,23 @@ def trace_and_on_node_processing(usr_argv)
     # Preprocess trace
     unless OPTIONS[:archive]
       lm_babeltrace(backends)
+      syncd.global_barrier
+      if OPTIONS.include?(:timeline)
+        # get the timeline per node
+        hostname_string=Socket.gethostname
+        # get list of hostnames
+        list_hostnames=get_hostnames()        
+        # find index of hostname_string in list_hostnames
+        hostname_id = list_hostnames.find_index(hostname_string)
+        # compute the offset, based on splitting max_uint16_value by the number of hosts
+        max_uint16_value = (2**16) - 1
+        offset = (max_uint16_value / list_hostnames.length ) * hostname_id
+        backends = OPTIONS[:backends].join(',')
+        output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
+        args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
+        exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
+      end
+
       # Babeltrace have moved / tranformer lttng_trace_dir_tmp into thapi_trace_dir_tmp
       LOGGER.debug("Deleting #{lttng_trace_dir_tmp}")
       FileUtils.remove_dir(lttng_trace_dir_tmp) if File.exist?(lttng_trace_dir_tmp)
@@ -894,8 +924,7 @@ def gm_processing(folder)
   args = []
   if OPTIONS.include?(:timeline)
     # cat the timelines
-    list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
-
+    list_hostnames = get_hostnames()
     cmd="cat "
     list_hostnames.each do |host|
       cmd+=(thapi_trace_dir_root+"/"+host+"/"+OPTIONS[:timeline]+"_"+host+" ")

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -192,27 +192,33 @@ def mpi_master?
   mpi_rank_id.zero?
 end
 
-def get_hostnames
-  list_hostnames=[]
-  # first try via env
-  hostfile=env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
-  if hostfile.nil?
-    # if nil, try via directory structure
-    Dir.entries(File.dirname(thapi_trace_dir_tmp)).sort.each do |entry|
-      if File.directory?(File.join(File.dirname(thapi_trace_dir_tmp), entry)) and entry != '.' and entry != '..'
-        list_hostnames.push(entry)
-      end
-    end
+# returns an offset for each timeline file
+# this is based on chunking max_int32_value
+# into the number of nodes
+def get_offset
+  if not in_mpi_env?
+    # if not mpi, just return 0 offset
+    offset = 0
   else
-    list_hostnames = File.readlines( hostfile ).map(&:chomp)
+    # if we launch with a scheduler, we can read from a hostfile.
+    hostfile=env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
+    if hostfile.nil?
+      max_int32_value = (2**31) - 1
+      # want to chunk by reasonable amount. for now, assume a max of 100000 nodes and
+      # chunk max_int32_value by that. So each node gets ~20000 spots 
+      offset = (max_int32_value / 100000) * (mpi_rank_id / mpi_local_size).floor
+    else
+      list_hostnames = File.readlines( hostfile ).map(&:chomp)
+      hostname_string=Socket.gethostname
+      # find index of hostname_string in list_hostnames
+      hostname_id = list_hostnames.find_index(hostname_string)
+      # compute the offset, based on splitting max_int32_value by the number of hosts
+      max_int32_value = (2**31) - 1
+      offset = (max_int32_value / list_hostnames.length ) * hostname_id
+    end
   end
-  # if list_names is still empty
-  if list_hostnames.empty?
-    puts "It looks like the hostfile is empty for some reason. Need to debug."
-    exit 1
-  end
-    
-  return list_hostnames
+
+  return offset
 end
 
 #    _                    _
@@ -774,6 +780,13 @@ def lm_babeltrace(backends)
     [pid_bt, pid_dirwatch]
   else
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
+    if OPTIONS.include?(:timeline)
+      offset=get_offset()        
+      backends = OPTIONS[:backends].join(',')
+      output_per_host=File.join(thapi_trace_dir_tmp, "timeline_"+offset.to_s)
+      args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
+      exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
+      end
   end
 end
 
@@ -867,25 +880,6 @@ def trace_and_on_node_processing(usr_argv)
     # Preprocess trace
     unless OPTIONS[:archive]
       lm_babeltrace(backends)
-      # global barrier to ensure that all thapi_trace_dir_tmp are written per hostname.
-      # unless these directories are made previously
-      syncd.global_barrier
-      if OPTIONS.include?(:timeline)
-        # get the timeline per node
-        hostname_string=Socket.gethostname
-        # get list of hostnames
-        list_hostnames=get_hostnames()        
-        # find index of hostname_string in list_hostnames
-        hostname_id = list_hostnames.find_index(hostname_string)
-        # compute the offset, based on splitting max_uint16_value by the number of hosts
-        max_uint16_value = (2**16) - 1
-        offset = (max_uint16_value / list_hostnames.length ) * hostname_id
-        backends = OPTIONS[:backends].join(',')
-        output_per_host=File.join(thapi_trace_dir_tmp, OPTIONS[:timeline]+"_"+hostname_string)
-        args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
-        exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
-      end
-
       # Babeltrace have moved / tranformer lttng_trace_dir_tmp into thapi_trace_dir_tmp
       LOGGER.debug("Deleting #{lttng_trace_dir_tmp}")
       FileUtils.remove_dir(lttng_trace_dir_tmp) if File.exist?(lttng_trace_dir_tmp)
@@ -907,10 +901,10 @@ def gm_processing(folder)
   args = []
   if OPTIONS.include?(:timeline)
     # cat the timelines
-    list_hostnames = get_hostnames()
+    # if -l -r, run to check, 
     cmd="cat "
-    list_hostnames.each do |host|
-      cmd+=(thapi_trace_dir_root+"/"+host+"/"+OPTIONS[:timeline]+"_"+host+" ")
+    Dir[thapi_trace_dir_root+"/*/timeline_*"].each do|f|
+      cmd+=(f+" ")
     end
     cmd+= ("> "+OPTIONS[:timeline])
     exec("#{cmd}")

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -192,6 +192,17 @@ def mpi_master?
   mpi_rank_id.zero?
 end
 
+def get_hostfile
+  hostfile=env_fetch_first('COBALT_NODEFILE', 'PBS_NODEFILE')
+  # one alternative could be to list hostnames under parent(thapi_trace_dir_tmp)
+  if hostfile.nil?
+    puts "Exiting from timeline, need a hostfile"
+    exit
+  end
+  return hostfile
+end
+
+
 #    _                    _
 #   |_ _  |  _|  _  ._   |_) _. _|_ |_
 #   | (_) | (_| (/_ |    |  (_|  |_ | |
@@ -756,8 +767,8 @@ def lm_babeltrace(backends)
       # get the timeline per node
       # get hostname_id
       hostname_string=Socket.gethostname
-      # get list of hostnames
-      list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
+      # get list of hostnames      
+      list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
       # find index of hostname_string in list_hostnames
       hostname_id = list_hostnames.find_index(hostname_string)
       # compute the offset, based on splitting max_uint16_value by the number of hosts
@@ -883,7 +894,7 @@ def gm_processing(folder)
   args = []
   if OPTIONS.include?(:timeline)
     # cat the timelines
-    list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
+    list_hostnames = File.readlines( get_hostfile() ).map(&:chomp)
 
     cmd="cat "
     list_hostnames.each do |host|

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -881,7 +881,7 @@ def trace_and_on_node_processing(usr_argv)
         max_uint16_value = (2**16) - 1
         offset = (max_uint16_value / list_hostnames.length ) * hostname_id
         backends = OPTIONS[:backends].join(',')
-        output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
+        output_per_host=File.join(thapi_trace_dir_tmp, OPTIONS[:timeline]+"_"+hostname_string)
         args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
         exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
       end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -764,7 +764,7 @@ def lm_babeltrace(backends)
       max_uint16_value = (2**16) - 1
       offset = (max_uint16_value / list_hostnames.length ) * hostname_id
       backends = OPTIONS[:backends].join(',')
-      output_per_host=OPTIONS[:timeline]+"_"+hostname_string
+      output_per_host=thapi_trace_dir_tmp+"/"+OPTIONS[:timeline]+"_"+hostname_string
       args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
       exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
     end
@@ -888,7 +888,7 @@ def gm_processing(folder)
 
     cmd="cat "
     list_hostnames.each do |host|
-      cmd+=(OPTIONS[:timeline]+"_"+host+" ")
+      cmd+=(thapi_trace_dir_root+"/"+host+"/"+OPTIONS[:timeline]+"_"+host+" ")
     end
     cmd+= ("> "+OPTIONS[:timeline])
     exec("#{cmd}")

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -884,7 +884,6 @@ def gm_processing(folder)
   if OPTIONS.include?(:timeline)
     # cat the timelines
     list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
-    num_hosts=list_hostnames.length
 
     cmd="cat "
     list_hostnames.each do |host|

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -749,8 +749,28 @@ def lm_babeltrace(backends)
       sleep(LTTNG_DIRWATCH_LOCK_RETRY_DELAY)
     end
     [pid_bt, pid_dirwatch]
-  else
+  else    
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
+
+    # get the timeline per node
+    # get hostname_id
+    hostname_string=Socket.gethostname
+    # get list of hostnames
+    list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
+    # find index of hostname_string in list_hostnames
+    hostname_id = list_hostnames.find_index(hostname_string)
+    # compute the offset, based on splitting max_uint16_value by the number of hosts
+    max_uint16_value = (2**16) - 1
+    offset = (max_uint16_value / list_hostnames.length ) * hostname_id
+
+    # for dir_root, maybe need to wait since not copied yet.
+    if OPTIONS.include?(:timeline)
+      backends = OPTIONS[:backends].join(',')
+      output_per_host=OPTIONS[:timeline]+"_"+hostname_string
+      args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
+      exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
+    end
+
   end
 end
 
@@ -863,38 +883,49 @@ def gm_processing(folder)
   backends = OPTIONS[:backends].join(',')
 
   args = []
-  if OPTIONS.include?(:trace)
-    args += ['trace', '--restrict', '--context', '--backends', backends]
-  elsif OPTIONS.include?(:timeline)
-    args += ['timeline', '--backends', backends, '--output-path', OPTIONS[:timeline]]
+  if OPTIONS.include?(:timeline)
+    # cat the timelines
+    list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
+    num_hosts=list_hostnames.length
+
+    cmd="cat "
+    list_hostnames.each do |host|
+      cmd+=(OPTIONS[:timeline]+"_"+host+" ")
+    end
+    cmd+= ("> "+OPTIONS[:timeline])
+    exec("#{cmd}")
+    $?
   else
-    args += ['tally']
-    args << '--display_kernel_verbose' if OPTIONS.include?(:'kernel-verbose')
-    args << '--display_metadata' if OPTIONS.include?(:metadata)
-    args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
-    args << '--display_mode' << 'json' if OPTIONS.include?(:json)
-    args << '--backends' << backends
-    args << '--display' << 'extended' if OPTIONS.include?(:extended)
-  end
+    if OPTIONS.include?(:trace)
+      args += ['trace', '--restrict', '--context', '--backends', backends]
+    else
+      args += ['tally']
+      args << '--display_kernel_verbose' if OPTIONS.include?(:'kernel-verbose')
+      args << '--display_metadata' if OPTIONS.include?(:metadata)
+      args << '--display_name_max_size' << OPTIONS[:'max-name-size'].to_s
+      args << '--display_mode' << 'json' if OPTIONS.include?(:json)
+      args << '--backends' << backends
+      args << '--display' << 'extended' if OPTIONS.include?(:extended)
+    end
+    args += ['--', folder]
 
-  args += ['--', folder]
+    LOGGER.debug(cmdname)
+    LOGGER.debug(args)
 
-  LOGGER.debug(cmdname)
-  LOGGER.debug(args)
-
-  LOGGER.info_block('IO dump') do
-    fo = if OPTIONS[:'analysis-output']
-           File.open(OPTIONS[:'analysis-output'], 'w')
-         else
-           $stdout.dup
-         end
-    pipe = IO.popen([cmdname, *args])
-    pid = pipe.pid
-    fo.puts(pipe.readlines)
-    fo.close
-    _, status = Process.wait2(pid)
-    raise "#{cmdname} #{args} failed" unless status.success?
-    status
+    LOGGER.info_block('IO dump') do
+      fo = if OPTIONS[:'analysis-output']
+             File.open(OPTIONS[:'analysis-output'], 'w')
+           else
+             $stdout.dup
+           end
+      pipe = IO.popen([cmdname, *args])
+      pid = pipe.pid
+      fo.puts(pipe.readlines)
+      fo.close
+      _, status = Process.wait2(pid)
+      raise "#{cmdname} #{args} failed" unless status.success?
+      status
+    end
   end
 end
 

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -749,22 +749,20 @@ def lm_babeltrace(backends)
       sleep(LTTNG_DIRWATCH_LOCK_RETRY_DELAY)
     end
     [pid_bt, pid_dirwatch]
-  else    
+  else
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
 
-    # get the timeline per node
-    # get hostname_id
-    hostname_string=Socket.gethostname
-    # get list of hostnames
-    list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
-    # find index of hostname_string in list_hostnames
-    hostname_id = list_hostnames.find_index(hostname_string)
-    # compute the offset, based on splitting max_uint16_value by the number of hosts
-    max_uint16_value = (2**16) - 1
-    offset = (max_uint16_value / list_hostnames.length ) * hostname_id
-
-    # for dir_root, maybe need to wait since not copied yet.
     if OPTIONS.include?(:timeline)
+      # get the timeline per node
+      # get hostname_id
+      hostname_string=Socket.gethostname
+      # get list of hostnames
+      list_hostnames = File.readlines( ENV['COBALT_NODEFILE'] ).map(&:chomp)
+      # find index of hostname_string in list_hostnames
+      hostname_id = list_hostnames.find_index(hostname_string)
+      # compute the offset, based on splitting max_uint16_value by the number of hosts
+      max_uint16_value = (2**16) - 1
+      offset = (max_uint16_value / list_hostnames.length ) * hostname_id
       backends = OPTIONS[:backends].join(',')
       output_per_host=OPTIONS[:timeline]+"_"+hostname_string
       args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]


### PR DESCRIPTION
This changes thapi so that the timelines are generated per node and offset is used to keep the tracks of each timeline separate. The global master will then cat all the timelines together at the end. 

In particular, the timeline generation is changed from just being called once in gm_processing on the full interval to instead being call by each local master in lm_processing on the local host's interval, and then gm_processing only does a cat of the timeline.

In theory this should speed up the timeline generation by #nodes but I am still waiting on some timings. I will update with the timings when I can.

Let me know if there is anything to change, I'm not a ruby expert. In particular, comments on the usage of `exec` and `$?` in gm_processing to return the status are welcome, as I'm not sure if they are preferred here.