### PR TITLE
Fix gen_probe_base for function without parameter returning something

### DIFF
--- a/utils/gen_probe_base.rb
+++ b/utils/gen_probe_base.rb
@@ -13,7 +13,7 @@ $tracepoint_lambda = lambda { |provider, c, dir = nil|
       TP_ARGS(
   EOF
   print '    '
-  if (c.parameters.nil? || c.parameters.empty?) && !(c.has_return_type? && dir == :stop)
+  if (c.parameters.nil? || c.parameters.empty?) && !(c.has_return_type? && dir != :start)
     print 'void'
   else
     params = []


### PR DESCRIPTION
A function like
```
__itt_timestamp __itt_get_timestamp(void);
```
Is currently generate the tp
```
TRACEPOINT_EVENT(
  lttng_ust_itt,
  __itt_get_timestamp,
  TP_ARGS(
    void
  ),
  TP_FIELDS(
    ctf_integer(__itt_timestamp, ittResult, ittResult)
  )
)
```
This is obviously wrong. The `TP_FIELDS` are correct... So yeah, easy fix