### PR TITLE
add anywhere functions to init list

### DIFF
--- a/backends/mpi/mpi_model.rb
+++ b/backends/mpi/mpi_model.rb
@@ -22,34 +22,37 @@ gen_ffi_type_map(typedefs)
 mpi_funcs_e = $mpi_api['functions']
 
 INIT_FUNCTIONS = /
-  \b(?:
-    MPI_Init |
-    MPI_Init_thread |
-    MPI_Initialized |
-    MPI_Finalized |
-    MPI_Get_version |
-    MPI_Get_library_version |
-    MPI_Info_(
-      create(_env)? |
-      set | delete |
-      get_(string | nkeys | nthkey) |
-      dup | free | f2c | c2f
-    ) |
-    MPI_Session_(
-      create_errhandler |
-      call_errhandler
-    ) |
-    MPI_Errhandler_(
-      free | f2c | c2f
-    ) |
-    MPI_Error_(
-      string | class
-    ) |
-    MPI_(add|remove)_error_(
-      class | code | string
-    ) |
-    MPI_T_\w+
-  )\b
+  \b(?:MPI_Init|
+  MPI_Init_thread|
+  MPI_Initialized|
+  MPI_Finalized|
+  MPI_Get_version|
+  MPI_Get_library_version|
+  MPI_Info_create|
+  MPI_Info_create_env|
+  MPI_Info_set|
+  MPI_Info_delete|
+  MPI_Info_get_string|
+  MPI_Info_get_nkeys|
+  MPI_Info_get_nthkey|
+  MPI_Info_dup|
+  MPI_Info_free|
+  MPI_Info_f2c|
+  MPI_Info_c2f|
+  MPI_Session_create_errhandler|
+  MPI_Session_call_errhandler|
+  MPI_Errhandler_free|
+  MPI_Errhandler_f2c|
+  MPI_Errhandler_c2f|
+  MPI_Error_string|
+  MPI_Error_class|
+  MPI_Add_error_class|
+  MPI_Remove_error_class|
+  MPI_Add_error_code|
+  MPI_Remove_error_code|
+  MPI_Add_error_string|
+  MPI_Remove_error_string|
+  MPI_T_init_thread)\b
 /ix
 
 $mpi_meta_parameters = YAML.load_file(File.join(SRC_DIR, 'mpi_meta_parameters.yaml'))


### PR DESCRIPTION
This adds the "call from anywhere" functions [found here](https://www.mpi-forum.org/docs/mpi-4.1/mpi41-report/node277.htm) to the `INIT_FUNCTIONS` list.

I think I matched the case correctly but added a `/i` to the regex just in case.

Let me know if you want me to remove some of the regex shennanigans. I tried making it readable while still compact.

This fixes #426 