### PR TITLE
Cleaning up gm_processing so that there's only one call to run the command

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -784,10 +784,9 @@ def lm_babeltrace(backends)
   else
     exec("#{BINDIR}/babeltrace_thapi #{opts.join(' ')} -- #{lttng_trace_dir_tmp}")
     if OPTIONS.include?(:timeline)
-      offset=get_offset        
       backends = OPTIONS[:backends].join(',')
-      output_per_host=File.join(thapi_trace_dir_tmp, "timeline_"+offset.to_s+".pftrace")
-      args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', offset]
+      output_per_host=File.join(thapi_trace_dir_tmp, "timeline_"+get_offset.to_s+".pftrace")
+      args = ['timeline', '--backends', backends, '--output-path', output_per_host, '--output-offset', get_offset]
       exec("#{BINDIR}/babeltrace_thapi #{args.join(' ')}  #{thapi_trace_dir_tmp}")
       end
   end


### PR DESCRIPTION
This cleans up `gm_processing` so that now the if/else block creates a command list depending on the options, and runs it via one call to run_and_log_process.