### PR TITLE
Changes for missing mpi symbols for libmpifort since not in ABI

### DIFF
--- a/backends/mpi/Makefile.am
+++ b/backends/mpi/Makefile.am
@@ -121,7 +121,7 @@ nodist_libmpitracepoints_la_SOURCES = \
 	$(MPI_STATIC_PROBES_INCL) \
 	$(MPI_STATIC_PROBES_SRC)
 
-libmpitracepoints_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I$(srcdir)/include -I./
+libmpitracepoints_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I./modified_include -I./
 libmpitracepoints_la_CFLAGS = -fPIC -Wall -Wextra -Wno-unused-parameter -Wno-type-limits -Wno-sign-compare $(WERROR) $(LTTNG_UST_CFLAGS)
 libmpitracepoints_la_LDFLAGS = $(LTTNG_UST_LIBS)
 
@@ -136,7 +136,7 @@ nodist_libmpi_la_SOURCES = \
 	$(MPI_STATIC_PROBES_INCL) \
 	tracer_mpi.c
 
-libmpi_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I$(srcdir)/include -I./utils -I./
+libmpi_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I./modified_include -I./utils -I./
 libmpi_la_CFLAGS = -Wall -Wextra $(WERROR) $(LIBFFI_CFLAGS) $(LTTNG_UST_CFLAGS)
 libmpi_la_LDFLAGS = $(LTTNG_UST_LIBS) -ldl -lpthread
 libmpi_la_LDFLAGS += -version-info 12:0:0 # 12 is the current ABI version of all MPI implementation
@@ -203,7 +203,7 @@ nodist_libMPIInterval_la_SOURCES = \
 libMPIInterval_la_SOURCES = \
 	btx_mpiinterval_callbacks.cpp
 
-libMPIInterval_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I$(srcdir)/include -I./btx_filter_mpi
+libMPIInterval_la_CPPFLAGS = -I$(top_srcdir)/utils -I$(top_srcdir)/utils/include -I./modified_include -I./btx_filter_mpi
 libMPIInterval_la_CFLAGS = -Wall -Wextra -Wno-unused-parameter $(WERROR) $(BABELTRACE2_CFLAGS)
 libMPIInterval_la_CXXFLAGS = -std=c++17 -Wall -Wextra -Wno-unused-parameter $(WERROR) $(BABELTRACE2_CFLAGS)
 libMPIInterval_la_LDFLAGS = $(BABELTRACE2_LIBS) -avoid-version -module

--- a/backends/mpi/gen_mpi.rb
+++ b/backends/mpi/gen_mpi.rb
@@ -75,6 +75,7 @@ end
 
 puts <<~EOF
   #include <stdint.h>
+  #define MPICH_FORTRAN_SYMBOLS_NONABI
   #include <mpi.h>
   #include "mpi_tracepoints.h"
   #include "mpi_type.h"

--- a/backends/mpi/headers.patch
+++ b/backends/mpi/headers.patch
@@ -1,7 +1,7 @@
 diff -u4 -r --new-file include/mpi.h modified_include/mpi.h
---- include/mpi.h      2024-06-18 15:52:35.000000000 +0000
-+++ modified_include/mpi.h     2024-06-14 16:04:06.000000000 +0000
-@@ -1,7 +1,7 @@
+--- include/mpi.h	2025-10-21 02:20:59.000000000 +0000
++++ modified_include/mpi.h	2025-10-21 02:18:08.000000000 +0000
+@@ -1,8 +1,8 @@
  #ifndef MPI_H_ABI
  #define MPI_H_ABI
  
@@ -10,3 +10,33 @@ diff -u4 -r --new-file include/mpi.h modified_include/mpi.h
  
  #if defined(__cplusplus)
  extern "C" {
+ #endif
+@@ -1916,8 +1916,28 @@
+ int PMPI_T_source_get_info(int source_index, char *name, int *name_len, char *desc, int *desc_len, MPI_T_source_order *ordering, MPI_Count *ticks_per_second, MPI_Count *max_ticks, MPI_Info *info);
+ int PMPI_T_source_get_num(int *num_sources);
+ int PMPI_T_source_get_timestamp(int source_index, MPI_Count *timestamp);
+ 
++#ifdef MPICH_FORTRAN_SYMBOLS_NONABI
++
++// from src/mpi/topo/topoutil.c
++#undef MPI_UNWEIGHTED
++#undef MPI_WEIGHTS_EMPTY
++static int unweighted_dummy = 0x46618;
++static int weights_empty_dummy = 0x022284;
++/* cannot ==NULL, would be ambiguous */
++int *const MPI_UNWEIGHTED = &unweighted_dummy;
++int *const MPI_WEIGHTS_EMPTY = &weights_empty_dummy;
++
++// from src/mpi/init/globals.c
++#undef MPI_F_STATUS_IGNORE
++#undef MPI_F_STATUSES_IGNORE
++int *MPI_F_STATUS_IGNORE  = 0;
++int *MPI_F_STATUSES_IGNORE  = 0;
++
++#endif
++
++  
+ #if defined(__cplusplus)
+ }
+ #endif
+ 


### PR DESCRIPTION
We realized after `654c30e1666412927e280582eea8c9c03057e019` that this breaks fortran mpi applications since libmpifort.so relies on non-ABI symbol definitions from the system libmpi.so which it was built with. But after this commit to bump mpi.so to mpi.so.12, now at runtime it tries to resolve the symbols in libmpifort.so with thapi's mpi.so and will fail since thapi's mpi.so is only the ABI required things.

Without this change we get: 
```
> mpirun -n 1 /home/bertoni/projects/p76.thapi/THAPI_default/build/ici/bin/iprof -- ./a.out
./a.out: symbol lookup error: /opt/aurora/25.190.0/spack/unified/0.10.1/install/linux-sles15-x86_64/oneapi-2025.2.0/mpich-develop-git.6037a7a-cym6jg6/lib/libmpifort.so.12: undefined symbol: MPI_UNWEIGHTED
THAPI: Trace location: /home/bertoni/thapi-traces/thapi_aggreg--2025-10-21T14:59:44+00:00
```
for simple fotran mpi hello worlds.