### PR TITLE
Adding robustness to the hostname indexing

### DIFF
--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -251,8 +251,6 @@ module MPITopo
       number_hostname, hostname_index = if hostfile.nil?
                                           [10_000, rank_id / local_size]
                                         else
-                                          # splitting by "." in case the hostfile contains full hostnames with address
-                                          # (e.g. x4117c4s4b0n0.hsn.cm.aurora.alcf.anl.gov) and the Socket.gethostname is just x4117c4s4b0n0
                                           hostnames = File.readlines(hostfile)
                                           # find index of hostname_string in list_hostnames
                                           hostname_id = hostnames.find_index{ |host| host.start_with?(Socket.gethostname) }


### PR DESCRIPTION
When testing the timeline on Sunspot, we ran into a fail like:

```
> mpirun -n 2 -ppn 1 -- iprof -l -- gpu_tile_compact.sh ./flops
Single Precision Peak Flops: 42422 GFlop/s
Double Precision Peak Flops: 21316.3 GFlop/s
/opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:262:in `*': nil can't be coerced into Integer (TypeError)

      (MAX_UINT64_VALUE / number_hostname) * hostname_index
                                             ^^^^^^^^^^^^^^
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:262:in `rank_offset'
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:714:in `bt_analysis'
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:980:in `block in all_trace_and_processing'
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:469:in `open'
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:966:in `all_trace_and_processing'
        from /opt/aurora/26.26.0/spack/unified/1.1.1/install/linux-x86_64/thapi-git.426c8097e536fe40a8148bb83787ea695c91c57a_0.0.12-git.113-bstf5lt/bin/iprof:1121:in `<main>'
x1921c1s5b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: rank 1 exited with code 1
x1921c1s2b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov: rank 0 died from signal 15
```

This happened since hostname_id was `nil` since in `hostname_id = hostnames.find_index(Socket.gethostname)` `Socket.gethostname` was not found in the hostnames list. This was because the hostnames list on sunspot contains hostnames with `-hsn0` on them:

```
x1921c1s2b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov
x1921c1s5b0n0-hsn0.hsn.cm.sunspot.alcf.anl.gov
```

while `Socket.gethostname` returns just `x1921c1s2b0n0`. 

To work around this, this PR will get the index if the element in hostnames starts with the result of `Socket.gethostname` . This also raises an error and prints a message if the hostname_id is nil in the future for easier debugging. 

Thanks to @TApplencourt for advice on solution!