### PR TITLE
Remove `issue_489` tag

### DIFF
--- a/integration_tests/abnormal_usr_bin_exit.bats
+++ b/integration_tests/abnormal_usr_bin_exit.bats
@@ -10,8 +10,8 @@ bats_require_minimum_version 1.5.0
   out_txt=${BATS_TEST_TMPDIR}/out.txt
   LTTNG_UST_OPENCL_LIBOPENCL=$(whichlib64 clinfo libOpenCL.so) \
     run -2 iprof \
-        --analysis-output ${out_txt} \
-        -- bash -c "clinfo && echo \$BASHPID > ${lock_tmp} && sleep 100" &
+    --analysis-output ${out_txt} \
+    -- bash -c "clinfo && echo \$BASHPID > ${lock_tmp} && sleep 100" &
   until [ -f ${lock_tmp} ]; do sleep 1; done
   kill -2 $(cat ${lock_tmp})
   until [ -s ${out_txt} ]; do sleep 1; done

--- a/integration_tests/abnormal_usr_bin_exit.bats
+++ b/integration_tests/abnormal_usr_bin_exit.bats
@@ -5,11 +5,13 @@ bats_require_minimum_version 1.5.0
   run -55 iprof --no-analysis -- bash -c "exit 55"
 }
 
-# bats test_tags=issue_489
 @test "signaling_propagated_mpi" {
   lock_tmp=${BATS_TEST_TMPDIR}/lock.tmp
   out_txt=${BATS_TEST_TMPDIR}/out.txt
-  run -2 iprof --analysis-output ${out_txt} -- bash -c "clinfo &&  echo \$BASHPID > ${lock_tmp} && sleep 100" &
+  LTTNG_UST_OPENCL_LIBOPENCL=$(whichlib64 clinfo libOpenCL.so) \
+    run -2 iprof \
+        --analysis-output ${out_txt} \
+        -- bash -c "clinfo && echo \$BASHPID > ${lock_tmp} && sleep 100" &
   until [ -f ${lock_tmp} ]; do sleep 1; done
   kill -2 $(cat ${lock_tmp})
   until [ -s ${out_txt} ]; do sleep 1; done

--- a/integration_tests/general.bats
+++ b/integration_tests/general.bats
@@ -4,44 +4,37 @@ bats_require_minimum_version 1.5.0
   pkg-config --modversion thapi
 }
 
-# bats test_tags=issue_489
 @test "default_summary" {
   total_count=$(iprof --backend cl -- clinfo | awk -F'|' '/Total/ {print int($4)}')
   [ "$total_count" -ge 1 ]
 }
 
-# bats test_tags=issue_489
 @test "json_summary" {
   iprof --json --analysis-output out.json --json clinfo
   total_count=$(jq '.host["1"].data.Total.call' out.json)
   [ "$total_count" -ge 1 ]
 }
 
-# bats test_tags=issue_489
 @test "archive_summary" {
   total_count=$(iprof --backend cl --archive clinfo | awk -F'|' '/Total/ {print int($4)}')
   [ "$total_count" -ge 1 ]
 }
 
-# bats test_tags=issue_489
 @test "default_trace" {
   iprof -t clinfo | wc -l
 }
 
-# bats test_tags=issue_489
 @test "default_timeline" {
   run -0 iprof -l -- clinfo
   [[ "$output" =~ "THAPI: Perfetto trace location" ]]
   rm out.pftrace
 }
 
-# bats test_tags=issue_489
 @test "replay_summary" {
   iprof clinfo
   iprof -r
 }
 
-# bats test_tags=issue_489
 @test "no-analysis_output" {
   run -0 clinfo
   out1=$(echo "$output" | grep -v 'Max clock frequency' | grep -v '  Device LUID')
@@ -59,7 +52,6 @@ bats_require_minimum_version 1.5.0
   [[ "$stderr" =~ "error" ]]
 }
 
-# bats test_tags=issue_489
 @test "no-analysis_all" {
   iprof --no-analysis -- clinfo
   iprof -r
@@ -69,7 +61,6 @@ bats_require_minimum_version 1.5.0
   rm out.pftrace
 }
 
-# bats test_tags=issue_489
 @test "trace-output_all" {
   iprof --trace-output trace_1 -- clinfo
   iprof -r trace_1
@@ -84,14 +75,12 @@ bats_require_minimum_version 1.5.0
   rm -rf trace_3 out1.pftrace out2.pftrace
 }
 
-# bats test_tags=issue_489
 @test "timeline_output" {
   iprof -l roger.pftrace -- clinfo
   rm roger.pftrace
 }
 
 # Assert Failure
-# bats test_tags=issue_489
 @test "replay_negative" {
   iprof -- clinfo
   run iprof -t -r

--- a/integration_tests/parallel_execution.bats
+++ b/integration_tests/parallel_execution.bats
@@ -11,7 +11,6 @@ launch_mpi() {
   THAPI_SYNC_DAEMON=fs launch_mpi -n 2 ./integration_tests/light_iprof_only_sync.sh clinfo
 }
 
-# bats test_tags=issue_489
 @test "iprof_fs" {
   trace_dir="${BATS_TEST_TMPDIR}/${BATS_TEST_NAME}"
   THAPI_SYNC_DAEMON=fs launch_mpi -n 2 iprof --backend cl --no-analysis --trace-output ${trace_dir} -- clinfo
@@ -48,7 +47,6 @@ launch_mpi() {
 
 # Test Traced Rank
 
-# bats test_tags=issue_489
 @test "iprof_mpi+traced_ranks" {
   trace_dir="${BATS_TEST_TMPDIR}/${BATS_TEST_NAME}"
   run -0 launch_mpi -n 2 iprof --backend cl --traced-ranks 1 -- clinfo

--- a/integration_tests/whichlib64.bats
+++ b/integration_tests/whichlib64.bats
@@ -168,6 +168,7 @@ setup_ldconf() {
   [ "$output" = "$BATS_TEST_TMPDIR/rpath_dir/libbar.so.1" ]
 }
 
+# bats test_tags=need_patchelf
 @test "find_lib resolves DT_NEEDED soname via dlopen when no rpath" {
   build_libbar_versioned
   build_foo_no_rpath
@@ -200,6 +201,7 @@ setup_ldconf() {
   [[ "$stderr" == *"Warning: expected libbar.so.2 but found libbar.so.1"* ]]
 }
 
+# bats test_tags=need_patchelf
 @test "dlopen preserves SONAME filename when actual file has deeper version" {
   gcc -shared -Wl,-soname,libbar.so.1 -o "$BATS_TEST_TMPDIR/libbar.so.1.2" "$BATS_TEST_DIRNAME/bar.c"
   ln -s libbar.so.1.2 "$BATS_TEST_TMPDIR/libbar.so.1"
@@ -218,6 +220,7 @@ setup_ldconf() {
   [ "$output" = "$BATS_TEST_TMPDIR/lib/libbar.so" ]
 }
 
+# bats test_tags=need_patchelf
 @test "dlopen preserves symlinked directory in path (no rpath)" {
   mkdir -p "$BATS_TEST_TMPDIR/real_dir"
   build_libbar_versioned "$BATS_TEST_TMPDIR/real_dir"
@@ -228,6 +231,7 @@ setup_ldconf() {
   [ "$output" = "$BATS_TEST_TMPDIR/link_dir/libbar.so.1" ]
 }
 
+# bats test_tags=need_patchelf
 @test "cache lookup matches ldconfig for system library" {
   build_noop
   patchelf --remove-rpath "$BATS_TEST_TMPDIR/noop"
@@ -261,6 +265,7 @@ setup_ldconf() {
   [ "$output" = "$BATS_TEST_TMPDIR/libbar.so" ]
 }
 
+# bats test_tags=need_patchelf
 @test "search_default_paths reached with versioned DT_NEEDED, no rpath, no LD_LIBRARY_PATH" {
   build_libbar_versioned
   build_foo_no_rpath
@@ -312,6 +317,7 @@ setup_ldconf() {
   [ "$output" = "$BATS_TEST_TMPDIR/libdir/libbar.so.1" ]
 }
 
+# bats test_tags=need_patchelf
 @test "find_lib locates versioned library via ldconfig conf paths with DT_NEEDED" {
   mkdir -p "$BATS_TEST_TMPDIR/libdir"
   build_libbar_versioned "$BATS_TEST_TMPDIR/libdir"


### PR DESCRIPTION
The only trick is the 
`LTTNG_UST_OPENCL_LIBOPENCL=$(whichlib64 clinfo libOpenCL.so)`

when the `clinfo` binary is not used directly.