### PR TITLE
Fix unsigned params for babeltrace_thapi (display_name_max_size, offset)

### DIFF
--- a/integration_tests/general.bats
+++ b/integration_tests/general.bats
@@ -48,7 +48,7 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "stderr_output" {
-  run --separate-stderr iprof -- bash -c "echo \"error\" >&2"
+  run -0 --separate-stderr iprof -- bash -c "echo \"error\" >&2"
   [[ "$stderr" =~ "error" ]]
 }
 
@@ -100,6 +100,28 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "read_stdin" {
+  # NOTE: do not use `run -0` here. Combined with `bats_pipe`, it causes
+  # duplicated TAP lines in CI's second bats invocation (cause unknown).
   run bats_pipe echo "FOO" \| iprof cat
   [[ "$output" =~ "FOO" ]]
+}
+
+@test "max-name-size" {
+  # Truncation marker should appear when names are limited.
+  run -0 iprof --backend cl --max-name-size 10 -- clinfo
+  [[ "$output" =~ "[...]" ]]
+
+  # -1 means "no limit" (UINT64_MAX after the unsigned wrap). Regression guard
+  # against the params being decoded as garbage instead of UINT64_MAX.
+  run -0 iprof --backend cl --max-name-size -1 -- clinfo
+  [[ ! "$output" =~ "[...]" ]]
+}
+
+@test "timeline_output-offset_deterministic" {
+  # Two timeline runs against the same trace must produce identical files.
+  run -0 iprof --no-analysis -- clinfo
+  run -0 iprof -l out_a.pftrace -r
+  run -0 iprof -l out_b.pftrace -r
+  cmp out_a.pftrace out_b.pftrace
+  rm -f out_a.pftrace out_b.pftrace
 }

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -242,13 +242,13 @@ def get_and_add_components(graph, names, l_inputs)
                           'name' => $options[:name],
                           'display_mode' => $options[:'display-mode'],
                           'display_metadata' => $options[:'display-metadata'],
-                          'display_name_max_size' => "+#{$options[:'display-name-max-size']}",
+                          'display_name_max_size' => $options[:'display-name-max-size'],
                           'display_kernel_verbose' => $options[:'display-kernel-verbose'],
                           'backend_levels' => $options[:backends].join(',') })
     when 'sink.btx_timeline.timeline'
       graph.add(comp, 'timeline',
                 params: { 'output_path' => $options[:'output-path'],
-                          'offset' => "+#{$options[:'output-offset']}" })
+                          'offset' => $options[:'output-offset'] })
     when 'filter.utils.muxer'
       graph.add(comp, name)
     when 'filter.btx_aggreg.aggreg'


### PR DESCRIPTION
The previous workaround wrapped values as "+#{int}" strings, intending to mark them as babeltrace2 unsigned. But the Ruby BT2.from_value routes String to BTValueString, so the C side called bt_value_integer_unsigned_get on a string handle and got garbage. Pass bare Integers instead — from_value already routes >2**63-1 to BTValueIntegerUnsigned automatically.

Adds two regression tests in integration_tests/general.bats:
- max-name-size: truncation marker appears at small size, absent at -1
- timeline_output-offset_deterministic: two replays must produce identical files

Also adds run -0 to stderr_output and read_stdin which were using bare run but assumed exit 0.

Will fix https://github.com/argonne-lcf/THAPI/issues/498