### PR TITLE
sync_daemon_mpi: give daemon a distinct PMIX_NAMESPACE

### DIFF
--- a/xprof/sync_daemon_mpi.cpp
+++ b/xprof/sync_daemon_mpi.cpp
@@ -2,6 +2,7 @@
 #include "mpi.h"
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 using namespace daemon_proto;
 
@@ -124,6 +125,10 @@ int main(int argc, char **argv) {
     return 1;
   }
   const int fd = atoi(argv[1]);
+
+  // WA for MPI_Session bug when running concurrently with MPI apps.
+  if (const char *ns = getenv("PMIX_NAMESPACE"))
+    setenv("PMIX_NAMESPACE", (std::string(ns) + "_thapi_sync_daemon").c_str(), 1);
 
   CHECK_MPI(MPIX_Init_Session(&lib_shandle, &MPI_COMM_WORLD_THAPI));
   CHECK_MPI(MPI_Comm_split_type(MPI_COMM_WORLD_THAPI, MPI_COMM_TYPE_SHARED, 0, MPI_INFO_NULL,


### PR DESCRIPTION
The MPI sync daemon shares the traced application's inherited PMIx identity (PMIX_NAMESPACE). Two MPI instances claiming the same (namespace, rank) collide in the node-local SHM bootstrap and deadlock (n=128 --ppn 64) or abort with a truncation error (n=4).

Append a fixed suffix to PMIX_NAMESPACE before any MPI call so the daemon's session gets its own WORLD. Verified on 2 nodes with THAPI_SYNC_DAEMON=mpi: fix -> exit 0, full tally; control (fix disabled) -> hang. Default remains fs pending MPICH feedback.