### PR TITLE
mpi: dlopen real libmpi with RTLD_GLOBAL so unwrapped symbols resolve

### DIFF
--- a/backends/mpi/tracer_mpi_helpers.include.c
+++ b/backends/mpi/tracer_mpi_helpers.include.c
@@ -8,10 +8,17 @@ static void _load_tracer(void) {
   int verbose = 0;
 
   s = getenv("LTTNG_UST_MPI_LIBMPI");
+  /* RTLD_GLOBAL: promote the real libmpi's symbols into the global scope so
+   * that symbols we do NOT wrap (e.g. MPIX_GPU_query_support) remain resolvable
+   * by the traced application. With RTLD_LOCAL they were hidden, causing
+   * "undefined symbol" errors at lookup time. Our own preloaded wrappers still
+   * take precedence for the symbols we do wrap (they are earlier in the global
+   * scope), and RTLD_DEEPBIND keeps the real lib's internal calls bound to
+   * itself rather than re-entering our wrappers. */
   if (s)
-    handle = dlopen(s, RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    handle = dlopen(s, RTLD_LAZY | RTLD_GLOBAL | RTLD_DEEPBIND);
   else
-    handle = dlopen("libmpi.so", RTLD_LAZY | RTLD_LOCAL | RTLD_DEEPBIND);
+    handle = dlopen("libmpi.so", RTLD_LAZY | RTLD_GLOBAL | RTLD_DEEPBIND);
   if (handle) {
     void *ptr = dlsym(handle, "MPI_Init");
     if (ptr == (void *)&MPI_Init) { // opening oneself


### PR DESCRIPTION
The MPI tracer shim is LD_PRELOADed as libmpi.so and dlopen()s the real libmpi. It was opened with RTLD_LOCAL, which keeps the real library's symbols out of the global scope. Any MPI symbol the shim does not itself wrap (e.g. MPIX_GPU_query_support) then fails to resolve in the traced application:

  ./app: symbol lookup error: ./app: undefined symbol: MPIX_GPU_query_support

Switch both dlopen() calls (LTTNG_UST_MPI_LIBMPI and the libmpi.so fallback) to RTLD_GLOBAL, keeping RTLD_DEEPBIND. Our preloaded wrappers still take precedence for wrapped symbols since they are earlier in the global scope, and RTLD_DEEPBIND keeps the real lib's internal calls bound to itself rather than re-entering our wrappers.