### PR TITLE
Add sstream include to btx_zeinterval_callbacks.cpp

### DIFF
--- a/backends/ze/btx_zeinterval_callbacks.cpp
+++ b/backends/ze/btx_zeinterval_callbacks.cpp
@@ -5,8 +5,8 @@
 #include <iostream>
 #include <metababel/metababel.h>
 #include <regex>
-#include <string>
 #include <sstream>
+#include <string>
 #include <unordered_map>
 
 /*

--- a/backends/ze/btx_zeinterval_callbacks.cpp
+++ b/backends/ze/btx_zeinterval_callbacks.cpp
@@ -6,6 +6,7 @@
 #include <metababel/metababel.h>
 #include <regex>
 #include <string>
+#include <sstream>
 #include <unordered_map>
 
 /*


### PR DESCRIPTION
Should fix:
```
 libtool: compile:  g++ -std=c++17 -DHAVE_CONFIG_H -I. -I../../../backends/ze -I../../utils -I../../../utils -I../../../utils/include -I./modified_include -I./ -I./btx_filter_ze -std=c++17 -Wall -Wextra -Wno-unused-parameter -Werror -Wno-error=nonnull -g -O2 -MT libZEInterval_la-btx_zeinterval_callbacks.lo -MD -MP -MF .deps/libZEInterval_la-btx_zeinterval_callbacks.Tpo -c ../../../backends/ze/btx_zeinterval_callbacks.cpp  -fPIC -DPIC -o .libs/libZEInterval_la-btx_zeinterval_callbacks.o
  ../../../backends/ze/btx_zeinterval_callbacks.cpp: In function 'void hSignalEvent_hKernel_with_group_entry_callback(void*, void*, int64_t, const char*, const char*, int64_t, uint64_t, ze_command_list_handle_t, ze_kernel_handle_t, ze_group_count_t*)':
  ../../../backends/ze/btx_zeinterval_callbacks.cpp:437:23: error: aggregate 'std::stringstream metadata_s' has incomplete type and cannot be defined
  ```
  