### PR TITLE
ze: profile zeCommandListAppendMemoryCopyRegion (fixes #515)

### DIFF
--- a/backends/ze/btx_zeinterval_callbacks.cpp
+++ b/backends/ze/btx_zeinterval_callbacks.cpp
@@ -513,6 +513,38 @@ static void hSignalEvent_eventMemory_1ptr_entry_callback(void *btx_handle,
       hCommandList, name, ts, btx_event_t::TRAFFIC, btx_additional_info_traffic_t{ts, size}};
 }
 
+static void hSignalEvent_eventMemory_region_entry_callback(void *btx_handle,
+                                                           void *usr_data,
+                                                           int64_t ts,
+                                                           const char *event_class_name,
+                                                           const char *hostname,
+                                                           int64_t vpid,
+                                                           uint64_t vtid,
+                                                           ze_command_list_handle_t hCommandList,
+                                                           void *dstptr,
+                                                           void *srcptr,
+                                                           ze_copy_region_t *dstRegion_val) {
+
+  auto *data = static_cast<data_t *>(usr_data);
+  const hp_t hp{hostname, vpid};
+
+  // No `size` field on region copies: bytes are implicit in the descriptor.
+  // depth == 0 denotes a 2D copy, i.e. a single slice.
+  size_t size = (size_t)dstRegion_val->width * dstRegion_val->height *
+                (dstRegion_val->depth != 0 ? dstRegion_val->depth : 1);
+
+  std::string name;
+  {
+    std::stringstream ss_name;
+    ss_name << strip_event_class_name_entry(event_class_name) << "("
+            << memory_location(data, hp, (uintptr_t)srcptr) << "2"
+            << memory_location(data, hp, (uintptr_t)dstptr) << ")";
+    name = ss_name.str();
+  }
+  data->threadToLastLaunchInfo[{hostname, vpid, vtid}] = {
+      hCommandList, name, ts, btx_event_t::TRAFFIC, btx_additional_info_traffic_t{ts, size}};
+}
+
 static void eventMemory_without_hSignalEvent_entry_callback(void *btx_handle,
                                                             void *usr_data,
                                                             int64_t ts,
@@ -1426,6 +1458,7 @@ void btx_register_usr_callbacks(void *btx_handle) {
 
   REGISTER_ASSOCIATED_CALLBACK(hSignalEvent_eventMemory_2ptr_entry);
   REGISTER_ASSOCIATED_CALLBACK(hSignalEvent_eventMemory_1ptr_entry);
+  REGISTER_ASSOCIATED_CALLBACK(hSignalEvent_eventMemory_region_entry);
 
   REGISTER_ASSOCIATED_CALLBACK(eventMemory_without_hSignalEvent_entry);
   REGISTER_ASSOCIATED_CALLBACK(eventMemory_without_hSignalEvent_exit);

--- a/backends/ze/btx_zematching_model.yaml
+++ b/backends/ze/btx_zematching_model.yaml
@@ -145,6 +145,20 @@
       - :name: ^hCommandList$
       - :name: ^ptr$
       - :name: ^size$
+  - # Region copies (zeCommandListAppendMemoryCopyRegion): no `size` field; byte
+    # count is implicit in the region descriptor (width x height x depth). This
+    # leaf claims the eventMemory remainder that neither size-keyed set matched.
+    :set_id: hSignalEvent_eventMemory_region_entry
+    :domain: hSignalEvent_eventMemory_entry - (hSignalEvent_eventMemory_2ptr_entry + hSignalEvent_eventMemory_1ptr_entry)
+    :payload_field_class:
+      :type: structure
+      :members:
+      - :name: ^hCommandList$
+      - :name: ^dstptr$
+      - :name: ^srcptr$
+      - :name: ^dstRegion_val$
+        :field_class:
+          :cast_type: ze_copy_region_t \*
   - ## Rest of Traffic
     :set_id: eventMemory_without_hSignalEvent_entry
     :name: "Memory"


### PR DESCRIPTION
Fixes #515.

## Changes

1. Added a new matching rule `hSignalEvent_eventMemory_region_entry` in `btx_zematching_model.yaml` that matches region copies using the region descriptor (`dstRegion_val`) instead of the missing `size` field.
2. Added a new callback `hSignalEvent_eventMemory_region_entry_callback` in `btx_zeinterval_callbacks.cpp` that computes the byte count from the descriptor (`width * height * depth`), labels the transfer direction (e.g. `(M2D)`/`(D2M)`), and records it as memory traffic.
3. Registered that callback in `btx_zeinterval_callbacks.cpp` alongside the existing memory-copy callbacks.
