### PR TITLE
itt: emit `= {0}` instead of `= {}` for _retval

### DIFF
--- a/backends/itt/gen_itt.rb
+++ b/backends/itt/gen_itt.rb
@@ -9,7 +9,9 @@ $itt_commands.each do |c|
                     if c.type.is_a?(YAMLCAst::Pointer)
                       "#{c.type} _retval = calloc(1, sizeof(*_retval));"
                     else
-                      "#{c.type} _retval = {};"
+                      # `= {}` is C23, so use `= {0}` which also works for scalars
+                      # pre-C23. Can be modernized once we require C23.
+                      "#{c.type} _retval = {0};"
                     end)
 
   register_epilogue(c.name, 'return _retval;')


### PR DESCRIPTION
`Type _retval = {};` is an empty initializer, which is only valid for scalars from C23 on; older compilers reject it with "empty scalar initializer" (gcc 12 does, gcc 13 accepts it, which is why CI never caught this). `= {0}` zero-initializes both scalars and aggregates and is valid well before C23, so it keeps _retval initialized.

IF we move to c23 one-day, we can modernize the code. 