### PR TITLE
ze: make sampling interval configurable

### DIFF
--- a/backends/ze/ze_sampling_plugin.c
+++ b/backends/ze/ze_sampling_plugin.c
@@ -755,7 +755,10 @@ void thapi_initialize_sampling_plugin(void) {
 
   // register L0 sampler exactly once
   {
-    struct timespec interval = {.tv_sec = 0, .tv_nsec = 50000000}; /* 50 ms */
+    const char *s = getenv("LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS");
+    long milliseconds = s ? atol(s) : 50;
+    struct timespec interval = {.tv_sec = milliseconds / 1000,
+                                .tv_nsec = (milliseconds % 1000) * 1000000L};
     plugin_handle = thapi_register_sampling(&thapi_sampling_energy, &interval);
   }
   return;

--- a/integration_tests/sampling.bats
+++ b/integration_tests/sampling.bats
@@ -1,5 +1,49 @@
 bats_require_minimum_version 1.5.0
 
+@test "sampling_interval_help" {
+  run iprof --help
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-i, --sample-interval MS"* ]]
+  [[ "$output" == *"Default: 50"* ]]
+  [[ "$output" == *"frequency, energy, engine, fabric-port, and memory"* ]]
+}
+
+@test "sampling_interval_is_passed_to_ze_sampler" {
+  for option in -i --sample-interval; do
+    trace="sampling_interval_trace_${option#-}"
+    rm -rf "$trace"
+
+    LTTNG_UST_ZE_LIBZE_LOADER=/dev/null \
+      iprof --no-analysis --sample --backends ze "$option" 125 \
+      --trace-output "$trace" -- \
+      bash -c 'test "$LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS" = 125'
+  done
+}
+
+@test "sampling_interval_rejects_invalid_values" {
+  for interval in 0 -1 nope; do
+    run iprof --sample --sample-interval "$interval" -- true
+
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"ERROR:"* ]]
+  done
+}
+
+@test "sampling_interval_requires_sampling" {
+  run iprof --sample-interval 125 -- true
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--sample-interval requires --sample"* ]]
+}
+
+@test "sampling_interval_requires_ze_backend" {
+  run iprof --sample --sample-interval 125 --backends cxi -- true
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"--sample-interval requires the ze backend"* ]]
+}
+
 @test "sampling_heartbeat" {
   rm -rf heartbeat_trace
 

--- a/integration_tests/sampling.bats
+++ b/integration_tests/sampling.bats
@@ -1,49 +1,5 @@
 bats_require_minimum_version 1.5.0
 
-@test "sampling_interval_help" {
-  run iprof --help
-
-  [ "$status" -eq 0 ]
-  [[ "$output" == *"-i, --sample-interval MS"* ]]
-  [[ "$output" == *"Default: 50"* ]]
-  [[ "$output" == *"frequency, energy, engine, fabric-port, and memory"* ]]
-}
-
-@test "sampling_interval_is_passed_to_ze_sampler" {
-  for option in -i --sample-interval; do
-    trace="sampling_interval_trace_${option#-}"
-    rm -rf "$trace"
-
-    LTTNG_UST_ZE_LIBZE_LOADER=/dev/null \
-      iprof --no-analysis --sample --backends ze "$option" 125 \
-      --trace-output "$trace" -- \
-      bash -c 'test "$LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS" = 125'
-  done
-}
-
-@test "sampling_interval_rejects_invalid_values" {
-  for interval in 0 -1 nope; do
-    run iprof --sample --sample-interval "$interval" -- true
-
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"ERROR:"* ]]
-  done
-}
-
-@test "sampling_interval_requires_sampling" {
-  run iprof --sample-interval 125 -- true
-
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"--sample-interval requires --sample"* ]]
-}
-
-@test "sampling_interval_requires_ze_backend" {
-  run iprof --sample --sample-interval 125 --backends cxi -- true
-
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"--sample-interval requires the ze backend"* ]]
-}
-
 @test "sampling_heartbeat" {
   rm -rf heartbeat_trace
 

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -22,7 +22,7 @@ LTTNG_DIRWATCH_LOCK_RETRY_DELAY = 0.1
 MAX_UINT64_VALUE = (2**64) - 1
 SAMPLING_PERIOD_ENV = {
   'ze' => 'LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS',
-  'cxi' => 'LTTNG_UST_CXI_SAMPLING_CXI_PERIOD_MS'
+  'cxi' => 'LTTNG_UST_CXI_SAMPLING_CXI_PERIOD_MS',
 }.freeze
 
 $LOAD_PATH.unshift(DATADIR) if File.directory?(DATADIR)
@@ -144,7 +144,7 @@ end
 def parse_sampling_intervals(mappings)
   (mappings || []).each_with_object({}) do |mapping, intervals|
     backend, milliseconds = mapping.split(':', 2)
-    unless (SAMPLING_PERIOD_ENV.key?(backend) || backend == '*') && milliseconds&.match?(/\A[1-9]\d*\z/)
+    unless valid_sampling_interval?(backend, milliseconds)
       raise OptionParser::ParseError,
             "invalid sample interval #{mapping.inspect}; expected BACKEND:MS"
     end
@@ -152,6 +152,12 @@ def parse_sampling_intervals(mappings)
 
     intervals[backend] = milliseconds.to_i
   end
+end
+
+def valid_sampling_interval?(backend, milliseconds)
+  return false unless SAMPLING_PERIOD_ENV.key?(backend) || backend == '*'
+
+  milliseconds&.match?(/\A[1-9]\d*\z/)
 end
 
 # Wait until the block return true

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -20,6 +20,10 @@ LTTNG_ARCHIVE_TIMER = '60s'
 LTTNG_DIRWATCH_SIZE = '500' # In MiB
 LTTNG_DIRWATCH_LOCK_RETRY_DELAY = 0.1
 MAX_UINT64_VALUE = (2**64) - 1
+SAMPLING_PERIOD_ENV = {
+  'ze' => 'LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS',
+  'cxi' => 'LTTNG_UST_CXI_SAMPLING_CXI_PERIOD_MS'
+}.freeze
 
 $LOAD_PATH.unshift(DATADIR) if File.directory?(DATADIR)
 require 'open3'
@@ -135,6 +139,19 @@ end
 #
 def env_fetch_first(*args, default: nil)
   ENV.values_at(*args).compact.first || default
+end
+
+def parse_sampling_intervals(mappings)
+  (mappings || []).each_with_object({}) do |mapping, intervals|
+    backend, milliseconds = mapping.split(':', 2)
+    unless (SAMPLING_PERIOD_ENV.key?(backend) || backend == '*') && milliseconds&.match?(/\A[1-9]\d*\z/)
+      raise OptionParser::ParseError,
+            "invalid sample interval #{mapping.inspect}; expected BACKEND:MS"
+    end
+    raise OptionParser::ParseError, "duplicate sample interval backend #{backend}" if intervals.include?(backend)
+
+    intervals[backend] = milliseconds.to_i
+  end
 end
 
 # Wait until the block return true
@@ -928,7 +945,7 @@ def all_env_tracers(usr_binary)
       #   is to call zesInit and set ZES_ENABLE_SYSMAN to 0
       h['ZES_ENABLE_SYSMAN'] = 0
       h['LTTNG_UST_ZE_SAMPLING_ENERGY'] = 1
-      h['LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS'] = OPTIONS[:'sample-interval'] if OPTIONS.include?(:'sample-interval')
+      h[SAMPLING_PERIOD_ENV['ze']] = OPTIONS[:sample]['ze'] if OPTIONS[:sample].key?('ze')
       h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'ze', 'libZESampling.so')
     end
   end
@@ -942,6 +959,7 @@ def all_env_tracers(usr_binary)
     backends << 'cxi'
     if SamplingDaemon.active?
       h['LTTNG_UST_CXI_SAMPLING_CXI'] = 1
+      h[SAMPLING_PERIOD_ENV['cxi']] = OPTIONS[:sample]['cxi'] if OPTIONS[:sample].key?('cxi')
       h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'cxi', 'libCXISampling.so')
     end
   end
@@ -1067,14 +1085,11 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
             'Set the maximum allowed kernels name size.',
             'Use -1 for no limit.', default: 80)
 
-  parser.on('-s', '--sample', 'Enable counters sampling.')
-  parser.on('-i', '--sample-interval MS', OptionParser::DecimalInteger,
-            'Set the Level Zero telemetry sampling interval in milliseconds.',
-            'Controls frequency, energy, engine, fabric-port, and memory samples.',
-            'Default: 50 ms.') do |interval|
-    raise(OptionParser::ParseError, 'sample interval must be greater than zero') unless interval.positive?
-
-    interval
+  parser.on('-s', '--sample [MAPPINGS]', Array,
+            'Enable counters sampling.',
+            'Format: BACKEND:MS[,BACKEND:MS...].',
+            'Use *:MS to apply an interval to every selected sampling backend.') do |intervals|
+    parse_sampling_intervals(intervals)
   end
 
   parser.on('--metadata', 'Display trace metadata.')
@@ -1108,10 +1123,20 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
   begin
     parser.parse!(into: options)
     options[:'backend-names'] = options[:backends].map { |name_level| name_level.split(':').first }
-    if options.include?(:'sample-interval')
-      raise OptionParser::ParseError, '--sample-interval requires --sample' unless options[:sample]
-      unless options[:'backend-names'].include?('ze')
-        raise OptionParser::ParseError, '--sample-interval requires the ze backend'
+    if options.include?(:sample)
+      sampling_backends = options[:'backend-names'] & SAMPLING_PERIOD_ENV.keys
+      raise OptionParser::ParseError, '--sample requires a sampling backend' if sampling_backends.empty?
+
+      options[:sample].each_key do |backend|
+        next if backend == '*'
+
+        unless sampling_backends.include?(backend)
+          raise OptionParser::ParseError, "--sample backend #{backend} is not selected"
+        end
+      end
+      if (interval = options[:sample].delete('*'))
+        wildcard_intervals = sampling_backends.to_h { |backend| [backend, interval] }
+        options[:sample] = wildcard_intervals.merge(options[:sample])
       end
     end
   rescue OptionParser::InvalidOption => e

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -928,6 +928,7 @@ def all_env_tracers(usr_binary)
       #   is to call zesInit and set ZES_ENABLE_SYSMAN to 0
       h['ZES_ENABLE_SYSMAN'] = 0
       h['LTTNG_UST_ZE_SAMPLING_ENERGY'] = 1
+      h['LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS'] = OPTIONS[:'sample-interval'] if OPTIONS.include?(:'sample-interval')
       h['THAPI_SAMPLING_LIBRARIES'] << File.join(PKGLIBDIR, 'ze', 'libZESampling.so')
     end
   end
@@ -1067,6 +1068,14 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
             'Use -1 for no limit.', default: 80)
 
   parser.on('-s', '--sample', 'Enable counters sampling.')
+  parser.on('-i', '--sample-interval MS', OptionParser::DecimalInteger,
+            'Set the Level Zero telemetry sampling interval in milliseconds.',
+            'Controls frequency, energy, engine, fabric-port, and memory samples.',
+            'Default: 50 ms.') do |interval|
+    raise(OptionParser::ParseError, 'sample interval must be greater than zero') unless interval.positive?
+
+    interval
+  end
 
   parser.on('--metadata', 'Display trace metadata.')
   parser.on('-v', '--version', 'Print the Version String.') do
@@ -1098,6 +1107,13 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
   options = {}
   begin
     parser.parse!(into: options)
+    options[:'backend-names'] = options[:backends].map { |name_level| name_level.split(':').first }
+    if options.include?(:'sample-interval')
+      raise OptionParser::ParseError, '--sample-interval requires --sample' unless options[:sample]
+      unless options[:'backend-names'].include?('ze')
+        raise OptionParser::ParseError, '--sample-interval requires the ze backend'
+      end
+    end
   rescue OptionParser::InvalidOption => e
     puts("ERROR: #{e}. Maybe missing --?")
     print_help_and_exit(parser)
@@ -1106,7 +1122,6 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
     print_help_and_exit(parser)
   end
 
-  options[:'backend-names'] = options[:backends].map { |name_level| name_level.split(':').first }
   OPTIONS = options.freeze
 
   if (launcher = %w[mpirun mpiexec].find { |b| ARGV.include?(b) })


### PR DESCRIPTION

The Level Zero sampling is currently hardcoded every 50 ms. This change lets users select the interval at runtime through `iprof -i MS` or `iprof --sample-interval MS`.


- Added `-i MS` and `--sample-interval MS` to the `iprof` CLI.
- Require `--sample` and the `ze` backend when an interval is supplied.
- Pass the selected value through `LTTNG_UST_ZE_SAMPLING_ENERGY_PERIOD_MS`.
- Convert milliseconds into normalized `timespec` seconds/nanoseconds in the ZE sampler.
- Keep the existing combined callback unchanged. The interval applies to frequency, energy, engine, fabric-port, and memory telemetry.
- Added sampling integration coverage for help output, both aliases, propagation, invalid values, and required options.
