### PR TITLE
utils: rename generated version file to thapi_version

### DIFF
--- a/backends/cuda/tracer_cuda.sh.in
+++ b/backends/cuda/tracer_cuda.sh.in
@@ -47,7 +47,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/hip/tracer_hip.sh.in
+++ b/backends/hip/tracer_hip.sh.in
@@ -41,7 +41,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/itt/tracer_itt.sh.in
+++ b/backends/itt/tracer_itt.sh.in
@@ -15,7 +15,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/mpi/tracer_mpi.sh.in
+++ b/backends/mpi/tracer_mpi.sh.in
@@ -41,7 +41,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/omp/tracer_omp.sh.in
+++ b/backends/omp/tracer_omp.sh.in
@@ -17,7 +17,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/opencl/tracer_opencl.sh.in
+++ b/backends/opencl/tracer_opencl.sh.in
@@ -53,7 +53,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/backends/ze/tracer_ze.sh.in
+++ b/backends/ze/tracer_ze.sh.in
@@ -47,7 +47,7 @@ display_help() {
 }
 
 display_version() {
-  cat $datadir/version
+  cat $datadir/thapi_version
   exit 1
 }
 

--- a/utils/Makefile.am
+++ b/utils/Makefile.am
@@ -50,17 +50,17 @@ bin_SCRIPTS = \
 noinst_SCRIPTS = \
 	test_wrapper_thapi_text_pretty.sh
 
-.PHONY: version
+.PHONY: thapi_version
 
-version:
-	git describe --abbrev=7 --dirty --always --tags > version || echo $(PACKAGE_VERSION) > version
+thapi_version:
+	git describe --abbrev=7 --dirty --always --tags > thapi_version || echo $(PACKAGE_VERSION) > thapi_version
 
 data_DATA = \
-	version \
+	thapi_version \
 	optparse_thapi.rb
 
 CLEANFILES = \
-	version \
+	thapi_version \
 	optparse_thapi.rb \
 	lttng/tracepoint_gen.h \
 	$(BUILT_SOURCES)

--- a/utils/babeltrace_thapi.in
+++ b/utils/babeltrace_thapi.in
@@ -401,7 +401,7 @@ class BabeltraceParserThapi < OptionParserWithDefaultAndValidation
     on('--archive-session-found-file-path PATH')
     on('--[no-]muxer')
     on('-v', '--version', 'Print the version string') do
-      puts File.read(File.join(DATADIR, 'version'))
+      puts File.read(File.join(DATADIR, 'thapi_version'))
       exit
     end
   end

--- a/xprof/xprof.rb.in
+++ b/xprof/xprof.rb.in
@@ -1070,7 +1070,7 @@ if $thapi_launch || __FILE__ == $PROGRAM_NAME
 
   parser.on('--metadata', 'Display trace metadata.')
   parser.on('-v', '--version', 'Print the Version String.') do
-    puts File.read(File.join(DATADIR, 'version'))
+    puts File.read(File.join(DATADIR, 'thapi_version'))
     exit
   end
   parser.on('-h', '--help', 'Display this message.') { print_help_and_exit(parser, exit_code: 0) }


### PR DESCRIPTION
C++ now use `version` as a official header. 

During code gen we generate `version` into `utils`. And then do `-I utils`. and them kaboom
```../utils/version:1:1: error: expected unqualified-id
    1 | 6130020
```
The easier change is to rename it to `thapi_version`