### PR TITLE
mpi: load the meta-parameters and reconcile them with the API

### DIFF
--- a/backends/mpi/mpi_meta_parameters.yaml
+++ b/backends/mpi/mpi_meta_parameters.yaml
@@ -1,9 +1,7 @@
 ---
-:meta_parameters:
+meta_parameters:
   MPI_Abort: []
-  MPI_Accumulate:
-  - - InScalar
-    - origin_addr
+  MPI_Accumulate: []
   MPI_Add_error_class:
   - - OutScalar
     - errorclass
@@ -11,168 +9,54 @@
   - - OutScalar
     - errorcode
   MPI_Add_error_string:
-  - - InScalar
+  - - InString
     - string
   MPI_Aint_add: []
   MPI_Aint_diff: []
-  MPI_Allgather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Allgather: []
   MPI_Allgather_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Allgatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
+  MPI_Allgatherv: []
   MPI_Allgatherv_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
-  MPI_Alloc_mem:
-  - - OutScalar
-    - baseptr
-  MPI_Allreduce:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Alloc_mem: []
+  MPI_Allreduce: []
   MPI_Allreduce_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Alltoall:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Alltoall: []
   MPI_Alltoall_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Alltoallv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
+  MPI_Alltoallv: []
   MPI_Alltoallv_init:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
   - - OutScalar
     - request
-  MPI_Alltoallw:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
+  MPI_Alltoallw: []
   MPI_Alltoallw_init:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
   - - OutScalar
     - request
   MPI_Attr_delete: []
   MPI_Attr_get:
   - - OutScalar
-    - attribute_val
-  - - OutScalar
     - flag
-  MPI_Attr_put:
-  - - InScalar
-    - attribute_val
+  MPI_Attr_put: []
   MPI_Barrier: []
   MPI_Barrier_init:
   - - OutScalar
     - request
-  MPI_Bcast:
-  - - InScalar
-    - buffer
+  MPI_Bcast: []
   MPI_Bcast_init:
-  - - InScalar
-    - buffer
   - - OutScalar
     - request
-  MPI_Bsend:
-  - - InScalar
-    - buf
+  MPI_Bsend: []
   MPI_Bsend_init:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
-  MPI_Buffer_attach:
-  - - InScalar
-    - buffer
+  MPI_Buffer_attach: []
   MPI_Buffer_detach:
-  - - OutScalar
-    - buffer_addr
   - - OutScalar
     - size
   MPI_Buffer_flush: []
@@ -186,33 +70,15 @@
   MPI_Cancel:
   - - InScalar
     - request
-  MPI_Cart_coords:
-  - - OutScalar
-    - coords
+  MPI_Cart_coords: []
   MPI_Cart_create:
-  - - InScalar
-    - dims
-  - - InScalar
-    - periods
   - - OutScalar
     - comm_cart
-  MPI_Cart_get:
-  - - OutScalar
-    - dims
-  - - OutScalar
-    - periods
-  - - OutScalar
-    - coords
+  MPI_Cart_get: []
   MPI_Cart_map:
-  - - InScalar
-    - dims
-  - - InScalar
-    - periods
   - - OutScalar
     - newrank
   MPI_Cart_rank:
-  - - InScalar
-    - coords
   - - OutScalar
     - rank
   MPI_Cart_shift:
@@ -221,27 +87,21 @@
   - - OutScalar
     - rank_dest
   MPI_Cart_sub:
-  - - InScalar
-    - remain_dims
   - - OutScalar
     - newcomm
   MPI_Cartdim_get:
   - - OutScalar
     - ndims
   MPI_Close_port:
-  - - InScalar
+  - - InString
     - port_name
   MPI_Comm_accept:
-  - - InScalar
+  - - InString
     - port_name
   - - OutScalar
     - newcomm
-  MPI_Comm_attach_buffer:
-  - - InScalar
-    - buffer
+  MPI_Comm_attach_buffer: []
   MPI_Comm_detach_buffer:
-  - - OutScalar
-    - buffer_addr
   - - OutScalar
     - size
   MPI_Comm_c2f: []
@@ -250,7 +110,7 @@
   - - OutScalar
     - result
   MPI_Comm_connect:
-  - - InScalar
+  - - InString
     - port_name
   - - OutScalar
     - newcomm
@@ -264,7 +124,7 @@
   - - OutScalar
     - errhandler
   MPI_Comm_create_from_group:
-  - - InScalar
+  - - InString
     - stringtag
   - - InScalar
     - newcomm
@@ -278,8 +138,6 @@
     - comm_delete_attr_fn
   - - OutScalar
     - comm_keyval
-  - - InScalar
-    - extra_state
   MPI_Comm_delete_attr: []
   MPI_Comm_delete_attr_function: []
   MPI_Comm_disconnect:
@@ -302,8 +160,6 @@
     - comm_keyval
   MPI_Comm_get_attr:
   - - OutScalar
-    - attribute_val
-  - - OutScalar
     - flag
   MPI_Comm_get_errhandler:
   - - OutScalar
@@ -312,7 +168,7 @@
   - - OutScalar
     - info_used
   MPI_Comm_get_name:
-  - - OutScalar
+  - - OutString
     - comm_name
   - - OutScalar
     - resultlen
@@ -347,39 +203,23 @@
   MPI_Comm_remote_size:
   - - OutScalar
     - size
-  MPI_Comm_set_attr:
-  - - InScalar
-    - attribute_val
+  MPI_Comm_set_attr: []
   MPI_Comm_set_errhandler: []
   MPI_Comm_set_info: []
   MPI_Comm_set_name:
-  - - InScalar
+  - - InString
     - comm_name
   MPI_Comm_size:
   - - OutScalar
     - size
   MPI_Comm_spawn:
-  - - InScalar
+  - - InString
     - command
-  - - InScalar
-    - argv
   - - OutScalar
     - intercomm
-  - - OutScalar
-    - array_of_errcodes
   MPI_Comm_spawn_multiple:
-  - - InScalar
-    - array_of_commands
-  - - InScalar
-    - array_of_argv
-  - - InScalar
-    - array_of_maxprocs
-  - - InScalar
-    - array_of_info
   - - OutScalar
     - intercomm
-  - - OutScalar
-    - array_of_errcodes
   MPI_Comm_split:
   - - OutScalar
     - newcomm
@@ -389,52 +229,20 @@
   MPI_Comm_test_inter:
   - - OutScalar
     - flag
-  MPI_Compare_and_swap:
-  - - InScalar
-    - origin_addr
-  - - InScalar
-    - compare_addr
-  - - OutScalar
-    - result_addr
+  MPI_Compare_and_swap: []
   MPI_Copy_function: []
   MPI_DUP_FN: []
   MPI_Datarep_conversion_function: []
   MPI_Datarep_extent_function: []
   MPI_Delete_function: []
-  MPI_Dims_create:
-  - - InScalar
-    - dims
+  MPI_Dims_create: []
   MPI_Dist_graph_create:
-  - - InScalar
-    - sources
-  - - InScalar
-    - degrees
-  - - InScalar
-    - destinations
-  - - InScalar
-    - weights
   - - InScalar
     - comm_dist_graph
   MPI_Dist_graph_create_adjacent:
   - - InScalar
-    - sources
-  - - InScalar
-    - sourceweights
-  - - InScalar
-    - destinations
-  - - InScalar
-    - destweights
-  - - InScalar
     - comm_dist_graph
-  MPI_Dist_graph_neighbors:
-  - - OutScalar
-    - sources
-  - - OutScalar
-    - sourceweights
-  - - OutScalar
-    - destinations
-  - - OutScalar
-    - destweights
+  MPI_Dist_graph_neighbors: []
   MPI_Dist_graph_neighbors_count:
   - - OutScalar
     - indegree
@@ -451,28 +259,16 @@
   - - OutScalar
     - errorclass
   MPI_Error_string:
-  - - OutScalar
+  - - OutString
     - string
   - - OutScalar
     - resultlen
-  MPI_Exscan:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Exscan: []
   MPI_Exscan_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_F_sync_reg: []
-  MPI_Fetch_and_op:
-  - - InScalar
-    - origin_addr
-  - - OutScalar
-    - result_addr
+  MPI_Fetch_and_op: []
   MPI_File_c2f: []
   MPI_File_call_errhandler: []
   MPI_File_close:
@@ -484,7 +280,7 @@
   - - OutScalar
     - errhandler
   MPI_File_delete:
-  - - InScalar
+  - - InString
     - filename
   MPI_File_errhandler_function: []
   MPI_File_f2c: []
@@ -525,116 +321,72 @@
     - etype
   - - OutScalar
     - filetype
-  - - OutScalar
+  - - OutString
     - datarep
   MPI_File_iread:
-  - - OutScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iread_all:
   - - OutScalar
-    - buf
-  - - OutScalar
     - request
   MPI_File_iread_at:
-  - - OutScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iread_at_all:
   - - OutScalar
-    - buf
-  - - OutScalar
     - request
   MPI_File_iread_shared:
   - - OutScalar
-    - buf
-  - - OutScalar
     - request
   MPI_File_iwrite:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iwrite_all:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iwrite_at:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iwrite_at_all:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_iwrite_shared:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_File_open:
-  - - InScalar
+  - - InString
     - filename
   - - OutScalar
     - fh
   MPI_File_preallocate: []
   MPI_File_read:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
   MPI_File_read_all:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
-  MPI_File_read_all_begin:
-  - - OutScalar
-    - buf
+  MPI_File_read_all_begin: []
   MPI_File_read_all_end:
-  - - OutScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_read_at:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
   MPI_File_read_at_all:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
-  MPI_File_read_at_all_begin:
-  - - OutScalar
-    - buf
+  MPI_File_read_at_all_begin: []
   MPI_File_read_at_all_end:
-  - - OutScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_read_ordered:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
-  MPI_File_read_ordered_begin:
-  - - OutScalar
-    - buf
+  MPI_File_read_ordered_begin: []
   MPI_File_read_ordered_end:
-  - - OutScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_read_shared:
-  - - OutScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_seek: []
@@ -644,113 +396,55 @@
   MPI_File_set_info: []
   MPI_File_set_size: []
   MPI_File_set_view:
-  - - InScalar
+  - - InString
     - datarep
   MPI_File_sync: []
   MPI_File_write:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_write_all:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
-  MPI_File_write_all_begin:
-  - - InScalar
-    - buf
+  MPI_File_write_all_begin: []
   MPI_File_write_all_end:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_write_at:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_write_at_all:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
-  MPI_File_write_at_all_begin:
-  - - InScalar
-    - buf
+  MPI_File_write_at_all_begin: []
   MPI_File_write_at_all_end:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_write_ordered:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
-  MPI_File_write_ordered_begin:
-  - - InScalar
-    - buf
+  MPI_File_write_ordered_begin: []
   MPI_File_write_ordered_end:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_File_write_shared:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
   MPI_Finalize: []
   MPI_Finalized:
   - - OutScalar
     - flag
-  MPI_Free_mem:
-  - - InScalar
-    - base
-  MPI_Gather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Free_mem: []
+  MPI_Gather: []
   MPI_Gather_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Gatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
+  MPI_Gatherv: []
   MPI_Gatherv_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
-  MPI_Get:
-  - - OutScalar
-    - origin_addr
-  MPI_Get_accumulate:
-  - - InScalar
-    - origin_addr
-  - - OutScalar
-    - result_addr
+  MPI_Get: []
+  MPI_Get_accumulate: []
   MPI_Get_address:
-  - - InScalar
-    - location
   - - OutScalar
     - address
   MPI_Get_count:
@@ -772,12 +466,12 @@
   - - OutScalar
     - hw_info
   MPI_Get_library_version:
-  - - InScalar
+  - - OutString
     - version
   - - OutScalar
     - resultlen
   MPI_Get_processor_name:
-  - - InScalar
+  - - OutString
     - name
   - - OutScalar
     - resultlen
@@ -787,21 +481,13 @@
   - - OutScalar
     - subversion
   MPI_Graph_create:
-  - - InScalar
-    - edges
   - - OutScalar
     - comm_graph
-  MPI_Graph_get:
-  - - InScalar
-    - edges
+  MPI_Graph_get: []
   MPI_Graph_map:
-  - - InScalar
-    - edges
   - - OutScalar
     - newrank
-  MPI_Graph_neighbors:
-  - - OutScalar
-    - neighbors
+  MPI_Graph_neighbors: []
   MPI_Graph_neighbors_count:
   - - OutScalar
     - nneighbors
@@ -821,8 +507,6 @@
     - free_fn
   - - InScalar
     - cancel_fn
-  - - InScalar
-    - extra_state
   - - OutScalar
     - request
   MPI_Group_c2f: []
@@ -833,8 +517,6 @@
   - - OutScalar
     - newgroup
   MPI_Group_excl:
-  - - InScalar
-    - ranks
   - - OutScalar
     - newgroup
   MPI_Group_f2c: []
@@ -842,13 +524,11 @@
   - - InScalar
     - group
   MPI_Group_from_session_pset:
-  - - InScalar
+  - - InString
     - pset_name
   - - OutScalar
     - newgroup
   MPI_Group_incl:
-  - - InScalar
-    - ranks
   - - OutScalar
     - newgroup
   MPI_Group_intersection:
@@ -862,116 +542,44 @@
   MPI_Group_size:
   - - OutScalar
     - size
-  MPI_Group_translate_ranks:
-  - - InScalar
-    - ranks1
-  - - OutScalar
-    - ranks2
+  MPI_Group_translate_ranks: []
   MPI_Group_union:
   - - OutScalar
     - newgroup
   MPI_Iallgather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Iallgatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
   MPI_Iallreduce:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Ialltoall:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Ialltoallv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
   - - OutScalar
     - request
   MPI_Ialltoallw:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
   - - OutScalar
     - request
   MPI_Ibarrier:
   - - OutScalar
     - request
   MPI_Ibcast:
-  - - InScalar
-    - buffer
   - - OutScalar
     - request
   MPI_Ibsend:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Iexscan:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Igather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Igatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
   MPI_Improbe:
@@ -982,69 +590,23 @@
   - - OutScalar
     - status
   MPI_Imrecv:
-  - - OutScalar
-    - buf
   - - InScalar
     - message
   - - OutScalar
     - request
   MPI_Ineighbor_allgather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Ineighbor_allgatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
   MPI_Ineighbor_alltoall:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Ineighbor_alltoallv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
   - - OutScalar
     - request
   MPI_Ineighbor_alltoallw:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
   - - OutScalar
     - request
   MPI_Info_c2f: []
@@ -1052,12 +614,10 @@
   - - OutScalar
     - info
   MPI_Info_create_env:
-  - - InScalar
-    - argv
   - - OutScalar
     - info
   MPI_Info_delete:
-  - - InScalar
+  - - InString
     - key
   MPI_Info_dup:
   - - OutScalar
@@ -1067,9 +627,9 @@
   - - InScalar
     - info
   MPI_Info_get:
-  - - InScalar
+  - - InString
     - key
-  - - OutScalar
+  - - OutString
     - value
   - - OutScalar
     - flag
@@ -1077,28 +637,28 @@
   - - OutScalar
     - nkeys
   MPI_Info_get_nthkey:
-  - - OutScalar
+  - - OutString
     - key
   MPI_Info_get_string:
-  - - InScalar
+  - - InString
     - key
   - - InScalar
     - buflen
-  - - OutScalar
+  - - OutString
     - value
   - - OutScalar
     - flag
   MPI_Info_get_valuelen:
-  - - InScalar
+  - - InString
     - key
   - - OutScalar
     - valuelen
   - - OutScalar
     - flag
   MPI_Info_set:
-  - - InScalar
+  - - InString
     - key
-  - - InScalar
+  - - InString
     - value
   MPI_Init:
   - - InScalar
@@ -1119,7 +679,7 @@
   - - OutScalar
     - newintercomm
   MPI_Intercomm_create_from_groups:
-  - - InScalar
+  - - InString
     - stringtag
   - - InScalar
     - newintercomm
@@ -1133,85 +693,41 @@
     - status
   MPI_Irecv:
   - - OutScalar
-    - buf
-  - - OutScalar
     - request
   MPI_Ireduce:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Ireduce_scatter:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
   - - OutScalar
     - request
   MPI_Ireduce_scatter_block:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Irsend:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Is_thread_main:
   - - OutScalar
     - flag
   MPI_Iscan:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Iscatter:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Iscatterv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - displs
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Isend:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Isendrecv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Isendrecv_replace:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Issend:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Keyval_create:
@@ -1221,15 +737,13 @@
     - delete_fn
   - - OutScalar
     - keyval
-  - - InScalar
-    - extra_state
   MPI_Keyval_free:
   - - InScalar
     - keyval
   MPI_Lookup_name:
-  - - InScalar
+  - - InString
     - service_name
-  - - OutScalar
+  - - OutString
     - port_name
   MPI_Message_c2f: []
   MPI_Message_f2c: []
@@ -1239,120 +753,30 @@
   - - OutScalar
     - status
   MPI_Mrecv:
-  - - OutScalar
-    - buf
   - - InScalar
     - message
   - - OutScalar
     - status
   MPI_NULL_COPY_FN: []
   MPI_NULL_DELETE_FN: []
-  MPI_Neighbor_allgather:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Neighbor_allgather: []
   MPI_Neighbor_allgather_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Neighbor_allgatherv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
+  MPI_Neighbor_allgatherv: []
   MPI_Neighbor_allgatherv_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - displs
   - - OutScalar
     - request
-  MPI_Neighbor_alltoall:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Neighbor_alltoall: []
   MPI_Neighbor_alltoall_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Neighbor_alltoallv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
+  MPI_Neighbor_alltoallv: []
   MPI_Neighbor_alltoallv_init:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
   - - OutScalar
     - request
-  MPI_Neighbor_alltoallw:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
+  MPI_Neighbor_alltoallw: []
   MPI_Neighbor_alltoallw_init:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - sdispls
-  - - InScalar
-    - sendtypes
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  - - InScalar
-    - rdispls
-  - - InScalar
-    - recvtypes
   - - OutScalar
     - request
   MPI_Op_c2f: []
@@ -1369,26 +793,18 @@
   - - InScalar
     - op
   MPI_Open_port:
-  - - OutScalar
+  - - OutString
     - port_name
   MPI_Pack:
   - - InScalar
-    - inbuf
-  - - OutScalar
-    - outbuf
-  - - InScalar
     - position
   MPI_Pack_external:
-  - - InScalar
+  - - InString
     - datarep
-  - - InScalar
-    - inbuf
-  - - OutScalar
-    - outbuf
   - - InScalar
     - position
   MPI_Pack_external_size:
-  - - InScalar
+  - - InString
     - datarep
   - - OutScalar
     - size
@@ -1400,13 +816,9 @@
     - flag
   MPI_Pcontrol: []
   MPI_Pready: []
-  MPI_Pready_list:
-  - - InScalar
-    - array_of_partitions
+  MPI_Pready_list: []
   MPI_Pready_range: []
   MPI_Precv_init:
-  - - InScalar
-    - buf
   - - InScalar
     - request
   MPI_Probe:
@@ -1414,82 +826,40 @@
     - status
   MPI_Psend_init:
   - - InScalar
-    - buf
-  - - InScalar
     - request
   MPI_Publish_name:
-  - - InScalar
+  - - InString
     - service_name
-  - - InScalar
+  - - InString
     - port_name
-  MPI_Put:
-  - - InScalar
-    - origin_addr
+  MPI_Put: []
   MPI_Query_thread:
   - - OutScalar
     - provided
   MPI_Raccumulate:
-  - - InScalar
-    - origin_addr
   - - OutScalar
     - request
   MPI_Recv:
   - - OutScalar
-    - buf
-  - - OutScalar
     - status
   MPI_Recv_init:
   - - OutScalar
-    - buf
-  - - OutScalar
     - request
-  MPI_Reduce:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Reduce: []
   MPI_Reduce_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Reduce_local:
-  - - InScalar
-    - inbuf
-  - - InScalar
-    - inoutbuf
-  MPI_Reduce_scatter:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
-  MPI_Reduce_scatter_block:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Reduce_local: []
+  MPI_Reduce_scatter: []
+  MPI_Reduce_scatter_block: []
   MPI_Reduce_scatter_block_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
   MPI_Reduce_scatter_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
-  - - InScalar
-    - recvcounts
   - - OutScalar
     - request
   MPI_Register_datarep:
-  - - InScalar
+  - - InString
     - datarep
   - - InScalar
     - read_conversion_fn
@@ -1497,8 +867,6 @@
     - write_conversion_fn
   - - InScalar
     - dtype_file_extent_fn
-  - - InScalar
-    - extra_state
   MPI_Remove_error_class: []
   MPI_Remove_error_code: []
   MPI_Remove_error_string: []
@@ -1513,123 +881,53 @@
   - - OutScalar
     - status
   MPI_Request_get_status_all:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - flag
-  - - OutScalar
-    - array_of_statuses
   MPI_Request_get_status_any:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - flag
   - - OutScalar
     - status
   MPI_Request_get_status_some:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - outcount
-  - - OutScalar
-    - array_of_indices
-  - - OutScalar
-    - array_of_statuses
   MPI_Rget:
-  - - OutScalar
-    - origin_addr
   - - OutScalar
     - request
   MPI_Rget_accumulate:
-  - - InScalar
-    - origin_addr
-  - - OutScalar
-    - result_addr
   - - OutScalar
     - request
   MPI_Rput:
-  - - InScalar
-    - origin_addr
   - - OutScalar
     - request
-  MPI_Rsend:
-  - - InScalar
-    - buf
+  MPI_Rsend: []
   MPI_Rsend_init:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
-  MPI_Scan:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Scan: []
   MPI_Scan_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Scatter:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
+  MPI_Scatter: []
   MPI_Scatter_init:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Scatterv:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - displs
-  - - OutScalar
-    - recvbuf
+  MPI_Scatterv: []
   MPI_Scatterv_init:
-  - - InScalar
-    - sendbuf
-  - - InScalar
-    - sendcounts
-  - - InScalar
-    - displs
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - request
-  MPI_Send:
-  - - InScalar
-    - buf
+  MPI_Send: []
   MPI_Send_init:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Sendrecv:
-  - - InScalar
-    - sendbuf
-  - - OutScalar
-    - recvbuf
   - - OutScalar
     - status
   MPI_Sendrecv_replace:
-  - - InScalar
-    - buf
   - - OutScalar
     - status
-  MPI_Session_attach_buffer:
-  - - InScalar
-    - buffer
+  MPI_Session_attach_buffer: []
   MPI_Session_detach_buffer:
-  - - OutScalar
-    - buffer_addr
   - - OutScalar
     - size
   MPI_Session_c2f: []
@@ -1654,13 +952,13 @@
   MPI_Session_get_nth_pset:
   - - InScalar
     - pset_len
-  - - InScalar
+  - - OutString
     - pset_name
   MPI_Session_get_num_psets:
   - - InScalar
     - npset_names
   MPI_Session_get_pset_info:
-  - - InScalar
+  - - InString
     - pset_name
   - - InScalar
     - info
@@ -1672,20 +970,14 @@
     - session
   MPI_Session_set_errhandler: []
   MPI_Sizeof: []
-  MPI_Ssend:
-  - - InScalar
-    - buf
+  MPI_Ssend: []
   MPI_Ssend_init:
-  - - InScalar
-    - buf
   - - OutScalar
     - request
   MPI_Start:
   - - InScalar
     - request
-  MPI_Startall:
-  - - InScalar
-    - array_of_requests
+  MPI_Startall: []
   MPI_Status_c2f:
   - - InScalar
     - c_status
@@ -1755,26 +1047,20 @@
   MPI_T_category_changed:
   - - OutScalar
     - update_number
-  MPI_T_category_get_categories:
-  - - OutScalar
-    - indices
-  MPI_T_category_get_cvars:
-  - - OutScalar
-    - indices
-  MPI_T_category_get_events:
-  - - OutScalar
-    - indices
+  MPI_T_category_get_categories: []
+  MPI_T_category_get_cvars: []
+  MPI_T_category_get_events: []
   MPI_T_category_get_index:
-  - - InScalar
+  - - InString
     - name
   - - OutScalar
     - cat_index
   MPI_T_category_get_info:
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
-  - - OutScalar
+  - - OutString
     - desc
   - - InScalar
     - desc_len
@@ -1790,16 +1076,14 @@
   MPI_T_category_get_num_events:
   - - OutScalar
     - num_events
-  MPI_T_category_get_pvars:
-  - - OutScalar
-    - indices
+  MPI_T_category_get_pvars: []
   MPI_T_cvar_get_index:
-  - - InScalar
+  - - InString
     - name
   - - OutScalar
     - cvar_index
   MPI_T_cvar_get_info:
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
@@ -1809,7 +1093,7 @@
     - datatype
   - - OutScalar
     - enumtype
-  - - OutScalar
+  - - OutString
     - desc
   - - InScalar
     - desc_len
@@ -1821,8 +1105,6 @@
   - - OutScalar
     - num_cvar
   MPI_T_cvar_handle_alloc:
-  - - InScalar
-    - obj_handle
   - - OutScalar
     - handle
   - - OutScalar
@@ -1830,23 +1112,19 @@
   MPI_T_cvar_handle_free:
   - - InScalar
     - handle
-  MPI_T_cvar_read:
-  - - OutScalar
-    - buf
-  MPI_T_cvar_write:
-  - - InScalar
-    - buf
+  MPI_T_cvar_read: []
+  MPI_T_cvar_write: []
   MPI_T_enum_get_info:
   - - OutScalar
     - num
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
   MPI_T_enum_get_item:
   - - OutScalar
     - value
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
@@ -1854,32 +1132,26 @@
   - - OutScalar
     - info_used
   MPI_T_event_callback_set_info: []
-  MPI_T_event_copy:
-  - - OutScalar
-    - buffer
+  MPI_T_event_copy: []
   MPI_T_event_get_index:
-  - - InScalar
+  - - InString
     - name
   - - OutScalar
     - event_index
   MPI_T_event_get_info:
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
   - - OutScalar
     - verbosity
-  - - OutScalar
-    - array_of_datatypes
-  - - OutScalar
-    - array_of_displacements
   - - InScalar
     - num_elements
   - - OutScalar
     - enumtype
   - - OutScalar
     - info
-  - - OutScalar
+  - - OutString
     - desc
   - - InScalar
     - desc_len
@@ -1895,8 +1167,6 @@
   - - OutScalar
     - event_timestamp
   MPI_T_event_handle_alloc:
-  - - InScalar
-    - obj_handle
   - - OutScalar
     - event_registration
   MPI_T_event_handle_free: []
@@ -1904,9 +1174,7 @@
   - - OutScalar
     - info_used
   MPI_T_event_handle_set_info: []
-  MPI_T_event_read:
-  - - OutScalar
-    - buffer
+  MPI_T_event_read: []
   MPI_T_event_register_callback: []
   MPI_T_event_set_dropped_handler: []
   MPI_T_finalize: []
@@ -1914,12 +1182,12 @@
   - - OutScalar
     - provided
   MPI_T_pvar_get_index:
-  - - InScalar
+  - - InString
     - name
   - - OutScalar
     - pvar_index
   MPI_T_pvar_get_info:
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
@@ -1931,7 +1199,7 @@
     - datatype
   - - OutScalar
     - enumtype
-  - - OutScalar
+  - - OutString
     - desc
   - - InScalar
     - desc_len
@@ -1947,8 +1215,6 @@
   - - OutScalar
     - num_pvar
   MPI_T_pvar_handle_alloc:
-  - - InScalar
-    - obj_handle
   - - OutScalar
     - handle
   - - OutScalar
@@ -1956,12 +1222,8 @@
   MPI_T_pvar_handle_free:
   - - InScalar
     - handle
-  MPI_T_pvar_read:
-  - - OutScalar
-    - buf
-  MPI_T_pvar_readreset:
-  - - OutScalar
-    - buf
+  MPI_T_pvar_read: []
+  MPI_T_pvar_readreset: []
   MPI_T_pvar_reset: []
   MPI_T_pvar_session_create:
   - - OutScalar
@@ -1971,15 +1233,13 @@
     - session
   MPI_T_pvar_start: []
   MPI_T_pvar_stop: []
-  MPI_T_pvar_write:
-  - - InScalar
-    - buf
+  MPI_T_pvar_write: []
   MPI_T_source_get_info:
-  - - OutScalar
+  - - OutString
     - name
   - - InScalar
     - name_len
-  - - OutScalar
+  - - OutString
     - desc
   - - InScalar
     - desc_len
@@ -2010,28 +1270,16 @@
   - - OutScalar
     - flag
   MPI_Testall:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - flag
-  - - OutScalar
-    - array_of_statuses
   MPI_Testany:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - flag
   - - OutScalar
     - status
   MPI_Testsome:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - outcount
-  - - OutScalar
-    - array_of_indices
-  - - OutScalar
-    - array_of_statuses
   MPI_Topo_test:
   - - InScalar
     - status
@@ -2044,14 +1292,6 @@
     - newtype
   MPI_Type_copy_attr_function: []
   MPI_Type_create_darray:
-  - - InScalar
-    - array_of_gsizes
-  - - InScalar
-    - array_of_distribs
-  - - InScalar
-    - array_of_dargs
-  - - InScalar
-    - array_of_psizes
   - - OutScalar
     - newtype
   MPI_Type_create_f90_complex:
@@ -2064,23 +1304,15 @@
   - - OutScalar
     - newtype
   MPI_Type_create_hindexed:
-  - - InScalar
-    - array_of_blocklengths
-  - - InScalar
-    - array_of_displacements
   - - OutScalar
     - newtype
   MPI_Type_create_hindexed_block:
-  - - InScalar
-    - array_of_displacements
   - - OutScalar
     - newtype
   MPI_Type_create_hvector:
   - - OutScalar
     - newtype
   MPI_Type_create_indexed_block:
-  - - InScalar
-    - array_of_displacements
   - - OutScalar
     - newtype
   MPI_Type_create_keyval:
@@ -2090,27 +1322,13 @@
     - type_delete_attr_fn
   - - OutScalar
     - type_keyval
-  - - InScalar
-    - extra_state
   MPI_Type_create_resized:
   - - OutScalar
     - newtype
   MPI_Type_create_struct:
-  - - InScalar
-    - array_of_blocklengths
-  - - InScalar
-    - array_of_displacements
-  - - InScalar
-    - array_of_types
   - - OutScalar
     - newtype
   MPI_Type_create_subarray:
-  - - InScalar
-    - array_of_sizes
-  - - InScalar
-    - array_of_subsizes
-  - - InScalar
-    - array_of_starts
   - - OutScalar
     - newtype
   MPI_Type_delete_attr: []
@@ -2127,16 +1345,8 @@
     - type_keyval
   MPI_Type_get_attr:
   - - OutScalar
-    - attribute_val
-  - - OutScalar
     - flag
-  MPI_Type_get_contents:
-  - - OutScalar
-    - array_of_integers
-  - - OutScalar
-    - array_of_addresses
-  - - OutScalar
-    - array_of_datatypes
+  MPI_Type_get_contents: []
   MPI_Type_get_envelope:
   - - OutScalar
     - num_integers
@@ -2157,7 +1367,7 @@
   - - OutScalar
     - extent
   MPI_Type_get_name:
-  - - OutScalar
+  - - OutString
     - type_name
   - - OutScalar
     - resultlen
@@ -2175,20 +1385,14 @@
   - - OutScalar
     - pair_type
   MPI_Type_indexed:
-  - - InScalar
-    - array_of_blocklengths
-  - - InScalar
-    - array_of_displacements
   - - OutScalar
     - newtype
   MPI_Type_match_size:
   - - OutScalar
     - datatype
-  MPI_Type_set_attr:
-  - - InScalar
-    - attribute_val
+  MPI_Type_set_attr: []
   MPI_Type_set_name:
-  - - InScalar
+  - - InString
     - type_name
   MPI_Type_size:
   - - OutScalar
@@ -2201,24 +1405,14 @@
     - newtype
   MPI_Unpack:
   - - InScalar
-    - inbuf
-  - - InScalar
     - position
-  - - OutScalar
-    - outbuf
   MPI_Unpack_external:
   - - InScalar
-    - datarep
-  - - InScalar
-    - inbuf
-  - - InScalar
     - position
-  - - OutScalar
-    - outbuf
   MPI_Unpublish_name:
-  - - InScalar
+  - - InString
     - service_name
-  - - InScalar
+  - - InString
     - port_name
   MPI_User_function: []
   MPI_WIN_DUP_FN: []
@@ -2229,45 +1423,25 @@
     - request
   - - OutScalar
     - status
-  MPI_Waitall:
-  - - InScalar
-    - array_of_requests
-  - - OutScalar
-    - array_of_statuses
+  MPI_Waitall: []
   MPI_Waitany:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - status
   MPI_Waitsome:
-  - - InScalar
-    - array_of_requests
   - - OutScalar
     - outcount
-  - - OutScalar
-    - array_of_indices
-  - - OutScalar
-    - array_of_statuses
   MPI_Win_allocate:
-  - - OutScalar
-    - baseptr
   - - OutScalar
     - win
   MPI_Win_allocate_shared:
   - - OutScalar
-    - baseptr
-  - - OutScalar
     - win
-  MPI_Win_attach:
-  - - InScalar
-    - base
+  MPI_Win_attach: []
   MPI_Win_c2f: []
   MPI_Win_call_errhandler: []
   MPI_Win_complete: []
   MPI_Win_copy_attr_function: []
   MPI_Win_create:
-  - - InScalar
-    - base
   - - OutScalar
     - win
   MPI_Win_create_dynamic:
@@ -2285,13 +1459,9 @@
     - win_delete_attr_fn
   - - OutScalar
     - win_keyval
-  - - InScalar
-    - extra_state
   MPI_Win_delete_attr: []
   MPI_Win_delete_attr_function: []
-  MPI_Win_detach:
-  - - InScalar
-    - base
+  MPI_Win_detach: []
   MPI_Win_errhandler_function: []
   MPI_Win_f2c: []
   MPI_Win_fence: []
@@ -2307,8 +1477,6 @@
     - win_keyval
   MPI_Win_get_attr:
   - - OutScalar
-    - attribute_val
-  - - OutScalar
     - flag
   MPI_Win_get_errhandler:
   - - OutScalar
@@ -2320,28 +1488,24 @@
   - - OutScalar
     - info_used
   MPI_Win_get_name:
-  - - OutScalar
+  - - OutString
     - win_name
   - - OutScalar
     - resultlen
   MPI_Win_lock: []
   MPI_Win_lock_all: []
   MPI_Win_post: []
-  MPI_Win_set_attr:
-  - - InScalar
-    - attribute_val
+  MPI_Win_set_attr: []
   MPI_Win_set_errhandler: []
   MPI_Win_set_info: []
   MPI_Win_set_name:
-  - - InScalar
+  - - InString
     - win_name
   MPI_Win_shared_query:
   - - OutScalar
     - size
   - - OutScalar
     - disp_unit
-  - - OutScalar
-    - baseptr
   MPI_Win_start: []
   MPI_Win_sync: []
   MPI_Win_test:


### PR DESCRIPTION
mpi_meta_parameters.yaml has never been loaded. Its top-level key is the Ruby symbol `:meta_parameters:`, but mpi_model.rb reads the string key `meta_parameters`, so `fetch` silently returned the default and MPI registered 0 of its 908 rows. Dead since 9ae9297 ("Backends folder").

Flipping the key alone crashes the generator: the data was machine generated as one InScalar/OutScalar row per pointer parameter and, never having been executed, drifted out of sync with the API. Reconciled by introspecting every row against mpi_api.yaml:

  - drop 246 rows on void* / const void* buffers (MPI_Allgather/sendbuf, MPI_Accumulate/origin_addr, ...). These have no lttng_type -- the payload is untyped bytes whose length lives in a separate count+datatype pair, so there is nothing to dereference. The buffer pointer itself is still traced.
  - drop 166 rows on array parameters (const int[], MPI_Request[], ...). ScalarMetaParameter requires a pointer; these need InArray/OutArray with a size argument, which the 2-element rows do not carry. Sizing them is per-function semantics (MPI_Allgatherv/recvcounts is sized by the communicator, MPI_Alltoallv's counts by nothing in the signature), not something to guess.
  - drop 6 array_of_statuses rows. They pass the pointer test but a scalar row would dump only element 0 of the array.
  - retype 58 char* rows to InString/OutString. As scalars they emitted ctf_integer(char, x_val, *x) -- a single byte of a NUL-terminated string. Direction now follows constness, which corrects three rows the generator had marked InScalar on non-const out-parameters (MPI_Get_library_version/version, MPI_Get_processor_name/name, MPI_Session_get_nth_pset/pset_name).

490 rows now register and emit: 212 ctf_integer_hex, 167 ctf_integer, 58 ctf_string, 53 ctf_sequence_text. All 536 function keys are kept so the file still lists the full API surface. The dropped rows are the ones that cannot be expressed as scalars; adding proper InArray/OutArray coverage for the buffer and array parameters is separate work.