### PR TITLE
mpi: emit the anonymous struct typedefs instead of dropping them

### DIFF
--- a/backends/mpi/gen_mpi_library.rb
+++ b/backends/mpi/gen_mpi_library.rb
@@ -66,7 +66,10 @@ $all_types.each do |t|
   elsif $objects.include?(t.name)
     print_mpi_object(t.name)
   elsif t.type.is_a? YAMLCAst::Struct
-    struct = $all_structs.find { |s| t.type.name == s.name }
+    # An anonymous target carries the layout itself, so the typedef is the
+    # definition -- same guard hip already uses. Without it MPI_Status and
+    # MPI_F08_status are silently dropped from the bindings.
+    struct = t.type.name ? $all_structs.find { |s| t.type.name == s.name } : t.type
     next unless struct
 
     print_struct(t.name, struct)


### PR DESCRIPTION
MPI_Status and MPI_F08_status are declared as typedefs of an anonymous struct, so the typedef carries the layout and mpi_api.yaml lists no separate struct for them -- it has no `structs` entries at all. The generator looked every struct typedef up by name in that empty list and skipped whatever it did not find, so both types were silently missing from mpi_library.rb.

hip already guards for this exact shape. Applying the same one-liner: when the target is anonymous, the typedef's own type is the definition.

Adds 16 lines to the generated mpi_library.rb -- the two classes and their by_value typedefs -- and changes nothing else.