### PR TITLE
ze: fix command_queue_group tracepoint to print all groups and use pCount

### DIFF
--- a/backends/ze/btx_zeinterval_callbacks.cpp
+++ b/backends/ze/btx_zeinterval_callbacks.cpp
@@ -193,14 +193,14 @@ property_command_queue_group_callback(void *btx_handle,
                                       uint64_t vtid,
                                       ze_driver_handle_t hDriver,
                                       ze_device_handle_t hDevice,
-                                      uint32_t numGroups,
-                                      size_t _pGroupProperties_val_length,
-                                      ze_command_queue_group_properties_t *pGroupProperties_val) {
+                                      uint32_t pCount,
+                                      size_t _pGroupProperties_vals_length,
+                                      ze_command_queue_group_properties_t *pGroupProperties_vals) {
 
   auto *data = static_cast<data_t *>(usr_data);
   data->command_queue_group_property[{hostname, vpid, (thapi_device_id)hDevice}] =
-      std::vector<ze_command_queue_group_properties_t>(pGroupProperties_val,
-                                                       pGroupProperties_val + numGroups);
+      std::vector<ze_command_queue_group_properties_t>(pGroupProperties_vals,
+                                                       pGroupProperties_vals + pCount);
 }
 
 static void property_subdevice_callback(void *btx_handle,

--- a/backends/ze/ze_events.yaml
+++ b/backends/ze/ze_events.yaml
@@ -164,13 +164,13 @@ lttng_ust_ze_properties:
     args:
     - [ze_driver_handle_t, hDriver]
     - [ze_device_handle_t, hDevice]
-    - [uint32_t, numGroups]
+    - [uint32_t, pCount]
     - [ze_command_queue_group_properties_t *, pGroupProperties]
     fields:
     - [ctf_integer_hex, uintptr_t, hDriver, "(uintptr_t)hDriver"]
     - [ctf_integer_hex, uintptr_t, hDevice, "(uintptr_t)hDevice"]
-    - [ctf_integer, uint32_t, numGroups, numGroups]
-    - [ctf_sequence_text, uint8_t, pGroupProperties_val, pGroupProperties, size_t, "numGroups * sizeof(ze_command_queue_group_properties_t)"]
+    - [ctf_integer, uint32_t, pCount, pCount]
+    - [ctf_sequence_text, uint8_t, pGroupProperties_vals, pGroupProperties, size_t, "pCount * sizeof(ze_command_queue_group_properties_t)"]
   - name: device_timer
     args:
     - [ze_device_handle_t, hDevice]

--- a/utils/gen_babeltrace_model_helper.rb
+++ b/utils/gen_babeltrace_model_helper.rb
@@ -75,7 +75,7 @@ def get_extra_fields_types_name(event)
   event['fields'].collect do |field|
     lttng = LTTng::TracepointField.new(*field)
     name = lttng.name.to_s
-    type = event['args'].find { |_t, n| n == name || n == name.gsub(/_val\z/, '') }[0]
+    type = event['args'].find { |_t, n| n == name || n == name.gsub(/_vals?\z/, '') }[0]
     case lttng.macro.to_s
     when /ctf_sequence/
       [['ctf_integer', 'size_t', "_#{name}_length", nil],


### PR DESCRIPTION
## Summary

Fixes the `lttng_ust_ze_properties:command_queue_group` property tracepoint (added in
#526), which had two inconsistencies with the Level Zero spec and the rest of THAPI.
Closes #532.

Validated on Aurora (Intel Data Center GPU Max 1550) with a fresh build.

---

## Bug 1 — only the first of N groups was printed

`pGroupProperties` is an array of `pCount` structs. The tracer captured **all** of them,
but the readable-trace pretty-printer decoded only **one** — so a device with 3 groups
showed a count of 3 next to a single group's properties. The other groups (typically the
copy-only engines) were silently dropped.

**Root cause:** the readable-trace codegen iterates a struct byte-sequence only when the
field name ends in `_vals` (plural). This field was named `pGroupProperties_val`
(singular), so it took the single-struct path. The bytes were never lost — only the
display was.

**Before** (`iprof -t`):
```
command_queue_group: { ... numGroups: 3,
  pGroupProperties_val: { ... flags: [ COMPUTE, COPY, COOPERATIVE_KERNELS ], numQueues: 1 } }
                        ↑ groups 2 and 3 (both COPY engines) missing
```

**What was missing:** groups 2 and 3 — present in the raw CTF
(`_pGroupProperties_val_length = 120 = 3 × 40`) but never rendered.

**After** (this PR):
```
command_queue_group: { ... pCount: 3, pGroupProperties_vals: [
  { ... flags: [ COMPUTE, COPY, COOPERATIVE_KERNELS ], maxMemoryFillPatternSize: -1, numQueues: 1 },
  { ... flags: [ COPY ], maxMemoryFillPatternSize: 1, numQueues: 1 },
  { ... flags: [ COPY ], maxMemoryFillPatternSize: 1, numQueues: 7 } ] }
```

**Fix:** rename the field `pGroupProperties_val` → `pGroupProperties_vals` so it uses the
existing array-iterating codegen path. This also required the curated-event arg matcher in
`gen_babeltrace_model_helper.rb` to strip a trailing `_vals` (not just `_val`) when
mapping a field back to its C arg for the type lookup. The C++ callback signature is
updated to match the regenerated field names.

---

## Bug 2 — count named `numGroups`, spec/THAPI call it `pCount`

The tracepoint named the group count `numGroups`, but the Level Zero API
`zeDeviceGetCommandQueueGroupProperties(hDevice, uint32_t* pCount, ...)` calls it
`pCount`, and THAPI's own `ze_meta_parameters.yaml` already models it as `pCount`.
`numGroups` appeared nowhere else in the tree.

**Before:** `... numGroups: 3, ...`
**After:** `... pCount: 3, ...`

**Fix:** rename the tracepoint arg/field `numGroups` → `pCount`.

---

## Changes

| File | Change |
|------|--------|
| `backends/ze/ze_events.yaml` | `numGroups`→`pCount` (arg + field); `pGroupProperties_val`→`pGroupProperties_vals`; size expr `numGroups`→`pCount` |
| `backends/ze/btx_zeinterval_callbacks.cpp` | callback params renamed to match regenerated field names |
| `utils/gen_babeltrace_model_helper.rb` | arg matcher strip `_val\z` → `_vals?\z` so the curated `_vals` field resolves its arg |

The tracer emit site (`tracer_ze_helpers.include.c`) is unchanged — it passes args
positionally to `do_tracepoint`.

## Validation & regression checks (same hardware run)

- ✅ `pCount: 3` and all 3 group structs printed (compute+copy, copy, copy×7 queues).
- ✅ `pCount` == number of array elements rendered.
- ✅ Singular `_val` events (`pDeviceProperties_val`, `pDriverProperties_val`) still render one struct.
- ✅ Other `_vals` struct-arrays (`pExtensionProperties_vals`) still iterate.
- ✅ Analysis/tally and `flags`-based engine-type labelling (the #506 feature) unaffected.
- ✅ No decode errors/exceptions in the readable trace.
