### PR TITLE
itt: stop doubling the ITT namespace in be_class names

### DIFF
--- a/backends/itt/gen_itt_library_base.rb
+++ b/backends/itt/gen_itt_library_base.rb
@@ -59,8 +59,11 @@ def to_class_name(name)
   mod + base
 end
 
+# to_class_name already carries the ITT:: namespace, and the library declares
+# its classes inside `module ITT`, where a leading ITT:: resolves to that same
+# module. Prefixing again produced ITT::ITT::Foo, which no constant matches.
 def to_scoped_class_name(name)
-  "ITT::#{to_class_name(name)}"
+  to_class_name(name)
 end
 
 def to_name_space(name)


### PR DESCRIPTION
The babeltrace model recorded ITT::ITT::IttId where the library defines ITT::IttId, so every pretty-printer that used one raised NameError:

  uninitialized constant ITT::ITT

to_class_name already returns a namespaced name ("ITT::IttId"): its `mod` comes from to_name_space, which upcases the __itt prefix. to_scoped_class_name then prefixed "ITT::" a second time. The five other backends do not have this problem -- their to_class_name emits no "::", so their scoped version is the only place the module is added.

The library declares these classes as `class ITT::IttId` inside `module ITT`, where the leading ITT:: resolves lexically to the enclosing module, so the constant lands at ITT::IttId and ITT::ITT::IttId never exists.

Affects 5 emitted lambdas across __itt_metadata_add, __itt_event_end and metadata. Regenerating changes only btx_itt_model.yaml and babeltrace_itt_lib.rb (5 lines each); itt_library.rb is untouched.

Verified by loading the generated itt_library.rb and resolving every be_class the model emits: both now resolve, where ITT::ITT::* raised.