### PR TITLE
ze: bind zex and transcribe the rest of its API

### DIFF
--- a/backends/ze/README.md
+++ b/backends/ze/README.md
@@ -89,8 +89,31 @@ grep "ZE_API_VERSION_CURRENT" ../include/ze_api.h # Sanity check
 
 ## 3/ Optional: ZEX
 
-- We are missing the `zex` header:
-- Found at `https://github.com/intel/compute-runtime/blob/master/level_zero/include/level_zero/driver_experimental/zex_api.h`
+- The `zex` (experimental) extensions come from compute-runtime, not the spec repo:
+  `https://github.com/intel/compute-runtime/tree/master/level_zero/include/level_zero/driver_experimental/`
+
+- Upstream is C++ despite the `.h`, so it cannot be included in our repo. The
+  signatures are plain C: our `include/zex_api.h` is a hand transcription of
+  just the entry points we trace.
+
+- To check which functions we don't trace yet:
+
+```bash
+$ diff <(grep -ho 'zex[A-Za-z]*(' /usr/include/level_zero/driver_experimental/*.h | tr -d '(' | sort -u) \
+       <(grep -o  'zex[A-Za-z]*(' include/zex_api.h | tr -d '(' | sort -u)
+```
+
+- Two manual changes when transcribing:
+
+  - Spell `zex_command_list_handle_t` / `zex_event_handle_t` as their `ze_`
+    originals (they are plain typedefs of them). One type must have one name:
+    metababel dispatches on field name plus type, and a field such as
+    `hSignalEvent` carrying both spellings is a conflicting signature.
+
+  - zex tags its structs with `ZEX_STRUCTURE_*` macros, not with members of
+    `ze_structure_type_t`. The generated bindings can only name an enum member,
+    so such a struct goes in `$struct_type_reject` in `ze_model.rb`; otherwise
+    `gen_ze_library.rb` raises `Unrecognized namespace`.
 
 ## Now Try to Compile:
 

--- a/backends/ze/gen_ze_library_base.rb
+++ b/backends/ze/gen_ze_library_base.rb
@@ -2,11 +2,15 @@ require_relative 'ze_model'
 require_relative '../../utils/gen_probe_base'
 require_relative '../../utils/gen_library_base'
 
-$all_types = $ze_api['typedefs'] + $zet_api['typedefs'] + $zes_api['typedefs'] + $zel_api['typedefs']
-$all_structs = $ze_api['structs'] + $zet_api['structs'] + $zes_api['structs'] + $zel_api['structs']
+$all_types = $ze_api['typedefs'] + $zet_api['typedefs'] + $zes_api['typedefs'] + $zel_api['typedefs'] +
+             $zex_api['typedefs']
+$all_structs = $ze_api['structs'] + $zet_api['structs'] + $zes_api['structs'] + $zel_api['structs'] +
+               $zex_api['structs']
 $all_unions = $zet_api['unions']
-$all_enums = $ze_api['enums'] + $zet_api['enums'] + $zes_api['enums'] + $zel_api['enums']
-$all_funcs = $ze_api['functions'] + $zet_api['functions'] + $zes_api['functions'] + $zel_api['functions']
+$all_enums = $ze_api['enums'] + $zet_api['enums'] + $zes_api['enums'] + $zel_api['enums'] +
+             $zex_api['enums']
+$all_funcs = $ze_api['functions'] + $zet_api['functions'] + $zes_api['functions'] + $zel_api['functions'] +
+             $zex_api['functions']
 $all_types_map = $all_types.collect { |t| [t.name, t.type] }.to_h
 
 $all_enum_names = []

--- a/backends/ze/include/zex_api.h
+++ b/backends/ze/include/zex_api.h
@@ -1,4 +1,7 @@
-// compute-runtime/level_zero/core/source/driver/extension_function_address.cpp
+// Hand transcription of the compute-runtime experimental (zex) API.
+// See README.md.
+//
+// https://github.com/intel/compute-runtime/tree/master/level_zero/include/level_zero/driver_experimental/
 #ifndef _ZEX_API_H
 #define _ZEX_API_H
 #if defined(__cplusplus)
@@ -11,12 +14,68 @@
 extern "C" {
 #endif
 
+// --- zex_common.h -----------------------------------------------------------
+
+typedef uint32_t zex_mem_action_scope_flags_t;
+typedef enum _zex_mem_action_scope_flag_t {
+    ZEX_MEM_ACTION_SCOPE_FLAG_SUBDEVICE = 1,
+    ZEX_MEM_ACTION_SCOPE_FLAG_DEVICE = 2,
+    ZEX_MEM_ACTION_SCOPE_FLAG_HOST = 4,
+    ZEX_MEM_ACTION_SCOPE_FLAG_FORCE_UINT32 = 0x7fffffff
+} zex_mem_action_scope_flag_t;
+
+typedef uint32_t zex_wait_on_mem_action_flags_t;
+typedef enum _zex_wait_on_mem_action_flag_t {
+    ZEX_WAIT_ON_MEMORY_FLAG_EQUAL = 1,
+    ZEX_WAIT_ON_MEMORY_FLAG_NOT_EQUAL = 2,
+    ZEX_WAIT_ON_MEMORY_FLAG_GREATER_THAN = 4,
+    ZEX_WAIT_ON_MEMORY_FLAG_GREATER_THAN_EQUAL = 8,
+    ZEX_WAIT_ON_MEMORY_FLAG_LESSER_THAN = 16,
+    ZEX_WAIT_ON_MEMORY_FLAG_LESSER_THAN_EQUAL = 32,
+    ZEX_WAIT_ON_MEMORY_FLAG_FORCE_UINT32 = 0x7fffffff
+} zex_wait_on_mem_action_flag_t;
+
+typedef struct _zex_wait_on_mem_desc_t {
+    zex_wait_on_mem_action_flags_t actionFlag;
+    zex_mem_action_scope_flags_t waitScope;
+} zex_wait_on_mem_desc_t;
+
+typedef struct _zex_write_to_mem_desc_t {
+    zex_mem_action_scope_flags_t writeScope;
+} zex_write_to_mem_desc_t;
+
+typedef struct _zex_ipc_counter_based_event_handle_t {
+    char data[ZE_MAX_IPC_HANDLE_SIZE];
+} zex_ipc_counter_based_event_handle_t;
+
+// --- zex_module.h -----------------------------------------------------------
+
 typedef struct _zex_device_module_register_file_exp_t {
     ze_structure_type_t stype;
     const void *pNext;
     uint32_t registerFileSizesCount;
     uint32_t *registerFileSizes;
 } zex_device_module_register_file_exp_t;
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexKernelGetBaseAddress(
+    ze_kernel_handle_t hKernel,
+    uint64_t *baseAddress);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexKernelGetArgumentSize(
+    ze_kernel_handle_t hKernel,
+    uint32_t argIndex,
+    uint32_t *pArgSize);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexKernelGetArgumentType(
+    ze_kernel_handle_t hKernel,
+    uint32_t argIndex,
+    uint32_t *pSize,
+    char *pString);
+
+// --- zex_driver.h -----------------------------------------------------------
 
 ZE_APIEXPORT ze_result_t ZE_APICALL
 zexDriverImportExternalPointer(
@@ -35,10 +94,7 @@ zexDriverGetHostPointerBaseAddress(
     void *ptr,
     void **baseAddress);
 
-ZE_APIEXPORT ze_result_t ZE_APICALL
-zexKernelGetBaseAddress(
-    ze_kernel_handle_t hKernel,
-    uint64_t *baseAddress);
+// --- zex_memory.h -----------------------------------------------------------
 
 ZE_APIEXPORT ze_result_t ZE_APICALL
 zexMemGetIpcHandles(
@@ -55,6 +111,69 @@ zexMemOpenIpcHandles(
     ze_ipc_mem_handle_t *pIpcHandles,
     ze_ipc_memory_flags_t flags,
     void **pptr);
+
+// --- zex_cmdlist.h ----------------------------------------------------------
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexCommandListAppendWaitOnMemory(
+    ze_command_list_handle_t hCommandList,
+    zex_wait_on_mem_desc_t *desc,
+    void *ptr,
+    uint32_t data,
+    ze_event_handle_t hSignalEvent);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexCommandListAppendWriteToMemory(
+    ze_command_list_handle_t hCommandList,
+    zex_write_to_mem_desc_t *desc,
+    void *ptr,
+    uint64_t data);
+
+// --- zex_event.h ------------------------------------------------------------
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexEventGetDeviceAddress(
+    ze_event_handle_t event,
+    uint64_t *completionValue,
+    uint64_t *address);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexCounterBasedEventCreate(
+    ze_context_handle_t hContext,
+    ze_device_handle_t hDevice,
+    uint64_t *deviceAddress,
+    uint64_t *hostAddress,
+    uint64_t completionValue,
+    const ze_event_desc_t *desc,
+    ze_event_handle_t *phEvent);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexCounterBasedEventGetIpcHandle(
+    ze_event_handle_t hEvent,
+    zex_ipc_counter_based_event_handle_t *phIpc);
+
+// zexCounterBasedEventOpenIpcHandle is deliberately absent: it takes a
+// 64-byte zex_ipc_counter_based_event_handle_t *by value*, which is class
+// MEMORY under the x86-64 SysV ABI (passed on the stack). The libffi closures
+// the zex tracer builds describe only scalars and pointers, so it cannot be
+// forwarded correctly, and declaring the parameter as a pointer would change
+// the ABI and misread the caller's arguments.
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexCounterBasedEventCloseIpcHandle(
+    ze_event_handle_t hEvent);
+
+// zexIntelAllocateNetworkInterrupt takes `uint32_t &` upstream, a C++
+// reference; transcribed as the pointer it is at the ABI level.
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexIntelAllocateNetworkInterrupt(
+    ze_context_handle_t hContext,
+    uint32_t *networkInterruptId);
+
+ZE_APIEXPORT ze_result_t ZE_APICALL
+zexIntelReleaseNetworkInterrupt(
+    ze_context_handle_t hContext,
+    uint32_t networkInterruptId);
 
 #if defined(__cplusplus)
 } // extern "C"

--- a/backends/ze/ze_model.rb
+++ b/backends/ze/ze_model.rb
@@ -62,7 +62,13 @@ $struct_type_conversion_table = {
   'ZES_STRUCTURE_TYPE_MEM_PAGE_OFFLINE_STATE_EXP' => 'ZES_STRUCTURE_TYPE_MEMORY_PAGE_OFFLINE_STATE_EXP',
 }
 
-$struct_type_reject = Set.new(['zet_metric_source_id_exp_t'])
+# Structs whose stype tag is not a member of ze_structure_type_t.
+#
+# - zex tags structures with a uint32_t alias (level_zero/ze_stypes.h) rather
+#   than an enum, we don't handle that.
+# - zet_metric_source_id_exp_t's tag is simply absent from the spec.
+$struct_type_reject = Set.new(%w[zet_metric_source_id_exp_t
+                                 zex_device_module_register_file_exp_t])
 
 $ze_meta_parameters = YAML.load_file(File.join(SRC_DIR, 'ze_meta_parameters.yaml'))
 $ze_meta_parameters['meta_parameters'].each do |func, list|


### PR DESCRIPTION
Just fixing zex.
Before we didn't pretty-printed them / traced them.

(checked on sunspot that they are now traced )