### PR TITLE
ze: stop doubling the zex namespace in class names

### DIFF
--- a/backends/ze/gen_ze_library_base.rb
+++ b/backends/ze/gen_ze_library_base.rb
@@ -2,12 +2,9 @@ require_relative 'ze_model'
 require_relative '../../utils/gen_probe_base'
 require_relative '../../utils/gen_library_base'
 
-# Which namespaces ze traces. zex and zer are absent from the class-name strip
-# below on purpose: their typedefs keep the namespace in the class name
-# (zex_wait_on_mem_desc_t -> ZEXZexWaitOnMemDesc), which is what the generated
-# bindings already spell.
-ZE_NAMESPACE_PATTERN = /\A(ze[xstlr]?)_/
-ZE_CLASS_STRIP_PATTERN = /\Aze[stl]?_/
+# Regex for finding the namespace prefix: zet_metric_properties_t -> zet_
+# No zer_, the raytracing types are spelled ze_rtas_*.
+ZE_NAMESPACE_PATTERN = /\A(ze[xstl]?)_/
 
 # The initialisms the word split would otherwise lower-case.
 ZE_INITIALISMS = { 'Uuid' => 'UUID', 'Dditable' => 'DDITable',
@@ -20,7 +17,7 @@ NAMING = NamingContext.new(
   strict: true,
   upcase_namespace: true,
   class_namer: lambda { |naming, name|
-    word_split_class_name(name, naming.name_space(name), ZE_CLASS_STRIP_PATTERN,
+    word_split_class_name(name, naming.name_space(name), ZE_NAMESPACE_PATTERN,
                           word_case: :downcase, initialisms: ZE_INITIALISMS)
   }
 )


### PR DESCRIPTION
Before we where generating: ZEXZexWaitOnMemDesc.
